### PR TITLE
Removed ip binding

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -54,7 +54,7 @@ Server.prototype._createServer = function(handler) {
     server = http.createServer(handler);
   }
 
-  server.listen(this.options.port, this.options.host);
+  server.listen(this.options.port);
 
   return server;
 };


### PR DESCRIPTION
This change is needed so that we can run the Bridge API on a host who's public IP address does not exist on any of its interfaces.