### PR TITLE
Prefer to use server.public.port over server.port for emails

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -77,6 +77,9 @@ Config.DEFAULTS = {
       key: null,
       ca: [],
       redirect: 80
+    },
+    public: {
+      port: 80
     }
   },
   network: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -79,6 +79,7 @@ Config.DEFAULTS = {
       redirect: 80
     },
     public: {
+      host: '127.0.0.1',
       port: 80
     }
   },

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -45,8 +45,8 @@ UsersRouter.prototype.createUser = function(req, res, next) {
     }
 
     function dispatchActivationEmail() {
-      let host = self.config.server.host;
       let profile = self.config.server.public || self.config.server;
+      let host = profile.host;
       let port = [443, 80].indexOf(profile.port) === -1 ?
                  ':' + profile.port :
                  '';

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -46,8 +46,9 @@ UsersRouter.prototype.createUser = function(req, res, next) {
 
     function dispatchActivationEmail() {
       let host = self.config.server.host;
-      let port = [443, 80].indexOf(self.config.server.port) === -1 ?
-                 ':' + self.config.server.port :
+      let profile = self.config.server.public || self.config.server;
+      let port = [443, 80].indexOf(profile.port) === -1 ?
+                 ':' + profile.port :
                  '';
       let proto = self.config.server.ssl &&
                   self.config.server.ssl.cert &&


### PR DESCRIPTION
Re: https://github.com/Storj/bridge/issues/69

This uses a new 'public' section of the server config if it exists, otherwise falls back to the current behavior.