### PR TITLE
Adding timeout option for nodejs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -72,6 +72,7 @@ Config.DEFAULTS = {
   server: {
     host: '127.0.0.1',
     port: 6382,
+    timeout: 240000,
     ssl: {
       cert: null,
       key: null,

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -54,6 +54,8 @@ Server.prototype._createServer = function(handler) {
     server = http.createServer(handler);
   }
 
+  server.timeout = this.options.timeout;
+
   server.listen(this.options.port);
 
   return server;


### PR DESCRIPTION
Increasing timeout may allow us to complete requests during higher traffic times while we tune the api.