### PR TITLE
add rabbitmq for minion communication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
 after_script:
   - npm run coverage
   - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
-services: mongodb
+services:
+  - mongodb
+  - rabbitmq

--- a/lib/config.js
+++ b/lib/config.js
@@ -69,6 +69,37 @@ Config.DEFAULTS = {
     mongos: false,
     ssl: false
   },
+  messaging: {
+    url: 'amqp://localhost',
+    queues: {
+      renterpool: { // a shared work queue
+        name: 'storj.work.renterpool',
+        options: {
+          exclusive: false,
+          durable: true,
+          arguments: {
+            messageTtl: 120 * 1000 // messages expires after 120 seconds with no response
+          }
+        }
+      },
+      callback: { // each process gets a unique callback queue, to use in replyTo
+        name: '', // dynamically generated
+        options: {
+          exclusive: true,
+          durable: false
+        }
+      }
+    },
+    exchanges: {
+      events: {
+        name: 'storj.events',
+        type: 'topic',
+        options: {
+          durable: true
+        }
+      }
+    }
+  },
   server: {
     host: '127.0.0.1',
     port: 6382,
@@ -93,6 +124,26 @@ Config.DEFAULTS = {
       noforward: true,
       tunnels: 32,
       tunport: 6384,
+      gateways: { min: 0, max: 0 }
+    },
+    {
+      bridge: false,
+      privkey: null,
+      address: '127.0.0.1',
+      port: 6385,
+      noforward: true,
+      tunnels: 32,
+      tunport: 6386,
+      gateways: { min: 0, max: 0 }
+    },
+    {
+      bridge: false,
+      privkey: null,
+      address: '127.0.0.1',
+      port: 6387,
+      noforward: true,
+      tunnels: 32,
+      tunport: 6388,
       gateways: { min: 0, max: 0 }
     }],
   },

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -11,6 +11,7 @@ const Storage = require('./storage');
 const RenterPool = require('./network/pool');
 const Server = require('./server');
 const Mailer = require('./mailer');
+const Messaging = require('./messaging');
 
 const log = require('./logger');
 
@@ -37,20 +38,21 @@ function Engine(config) {
 Engine.prototype.start = function(callback) {
   var self = this;
 
-  log.info('starting the bridge engine');
+  self.messaging = new Messaging(self._config.messaging);
 
+  log.info('starting the bridge engine');
   self.storage = new Storage(self._config.storage);
   self.mailer = new Mailer(self._config.mailer);
   self._config.network.storage = self.storage;
 
   log.info('opening interface to storj network');
 
-  let pool = new RenterPool(self._config.network);
-
-  self.network = pool;
+  self.network = new RenterPool(self._config.network, self.messaging);
   self.server = new Server(self._config.server, self._configureApp());
 
-  pool.on('ready', callback);
+  self.network.on('ready', () => {
+    self.messaging.start(callback);
+  });
 };
 
 /**

--- a/lib/messaging.js
+++ b/lib/messaging.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const async = require('async');
+const log = require('./logger');
+const amqplib = require('amqplib/callback_api');
+const EventEmitter = require('events').EventEmitter;
+const inherits = require('util').inherits;
+
+
+function Messaging(options) {
+  if (!(this instanceof Messaging)) {
+    return new Messaging(options);
+  }
+
+  this._options = options || {
+    url: 'amqp://localhost'
+  };
+  this._connection = null;
+  this.channels = {};
+  this.queues = {};
+  this.exchanges = {};
+
+  EventEmitter.call(this);
+}
+
+inherits(Messaging, EventEmitter);
+
+Messaging.prototype._connect = function start(callback) {
+  log.debug('Connecting to: %s', this._options.url);
+  amqplib.connect(this._options.url, (err, connection) => {
+    if (err) {
+      log.error(`Error connecting to %s: %s`, this._options.url, err.message);
+      return callback(err);
+    }
+    this._connection = connection;
+    callback();
+  });
+};
+
+Messaging.prototype._openChannels = function openChannels(callback) {
+  if (!this._connection) { return callback(new Error('Not connected')); }
+  log.debug('Opening messaging channels');
+  async.each(['serial', 'parallel'], (channelName, next) => {
+    this._connection.createChannel((err, channel) => {
+      if (err) {
+        log.error(`Error creating channel to %s: %s`, channelName, err.message);
+        return next(err);
+      }
+      if (channelName === 'serial') {
+        channel.prefetch = 1;
+      }
+      this.channels[channelName] = channel;
+      next();
+    });
+  }, callback);
+};
+
+Messaging.prototype._openQueues = function openQueues(callback) {
+  if (!this.channels || !this.channels.parallel) { return callback(new Error('Not connected')); }
+  log.debug('Opening messaging queues');
+  async.each(Object.keys(this._options.queues), (key, next) => {
+    this.channels.parallel.assertQueue(
+      this._options.queues[key].name,
+      this._options.queues[key].options,
+      (err, q) => {
+        if (err) { return next(err); }
+        this.queues[key] = q.queue;
+        next();
+      }
+    );
+  }, callback);
+};
+
+Messaging.prototype._openExchanges = function openExchanges(callback) {
+  if (!this.channels || !this.channels.parallel) { return callback(new Error('Not connected')); }
+  log.debug('Opening messaging exchanges');
+  async.each(Object.keys(this._options.exchanges), (key, next) => {
+    this.channels.parallel.assertExchange(
+      this._options.exchanges[key].name,
+      this._options.exchanges[key].type,
+      this._options.exchanges[key].options,
+      (err, ex) => {
+        if (err) { return next(err); }
+        this.exchanges[key] = ex;
+        next();
+      }
+    );
+  }, callback);
+};
+
+Messaging.prototype._listenForReplies = function listenForReplies(callback) {
+  log.info(`listening for messages on callback queue: ${this.queues.callback}`);
+  this.channels.parallel.consume(
+    this.queues.callback,
+    (msg) => {
+      log.debug(`Got message, emitting`);
+      this.emit('message', msg);
+    },
+    {noAck: true},
+    callback
+  );
+};
+
+Messaging.prototype._listenForWork = function listenForReplies(callback) {
+  log.info(`listening for messages on work queue: ${this.queues.renterpool}`);
+  this.channels.serial.consume(
+    this.queues.renterpool,
+    (msg) => {
+      this.emit('work', msg);
+    },
+    {noAck: false},
+    callback
+  );
+};
+
+Messaging.prototype.start = function start(worker, callback) {
+  log.info('starting messaging');
+  if (typeof worker === 'function') {
+    callback = worker;
+    worker = false;
+  }
+  async.series([
+    (next) => {
+      this._connect(next);
+    },
+    (next) => {
+      this._connect(next);
+    },
+    (next) => {
+      this._openChannels(next);
+    },
+    (next) => {
+      this._openQueues(next);
+    },
+    (next) => {
+      this._openExchanges(next);
+    },
+    (next) => {
+      this._listenForReplies(next);
+    },
+    (next) => {
+      if (worker) {
+        return this._listenForWork(next);
+      }
+      next();
+    }
+  ], callback);
+};
+
+Messaging.prototype.send = function send(message, queue, options) {
+  let channelName = 'parallel';
+  if (!this.channels || !this.channels[channelName]) {
+    log.error(`Could not send message on channel ${channelName}`);
+    return false;
+  }
+  log.info(`Sending message to ${queue}`);
+  return this.channels[channelName].sendToQueue(
+    queue,
+    new Buffer(message),
+    options
+  );
+};
+
+Messaging.prototype.publish = function publish(message, topic) {
+  return this.channels.parallel.publish(
+    this.exchanges.events,
+    topic,
+    new Buffer(message)
+  );
+};
+
+Messaging.prototype.subscribe = function subscribe(topic, callback) {
+  log.info(`Subscribing to ${topic} messages on ${this._options.exchanges.events.name}`);
+  this.channels.parallel.bindQueue(
+    this.queues.callback,
+    this._options.exchanges.events.name,
+    topic,
+    callback
+  );
+};
+
+module.exports = Messaging;

--- a/lib/network/pool.js
+++ b/lib/network/pool.js
@@ -16,16 +16,20 @@ const MongoAdapter = require('../storage/adapter');
  * @constructor
  * @param {Object} options - Network configuration
  */
-function RenterPool(options) {
+function RenterPool(options, messaging) {
   if (!(this instanceof RenterPool)) {
     return new RenterPool(options);
   }
 
   this._options = options;
   this._manager = new storj.Manager(new MongoAdapter(options.storage));
+  this.messaging = messaging;
+  this.messaging.on('message', (msg) => {
+    this._processMessage(msg);
+  });
+
   this._lastMinionIndex = 0;
   this._minions = {};
-  this._keys = {};
   this._pendingCallbacks = {};
 
   this._forkMinions();
@@ -42,19 +46,15 @@ inherits(RenterPool, EventEmitter);
  * Proxy RenterInterface#getStorageOffer
  */
 RenterPool.prototype.getStorageOffer = function(contract, callback) {
-  var nodeId = this._pluck()[1];
-
-  log.debug('Asking renter Minion to publish contract');
-
-  contract.set('renter_id', nodeId);
-  contract.sign('renter', this._keys[nodeId]);
-  this._send('getStorageOffer', [contract.toObject()], nodeId, callback);
+  log.info('[renterpool] getting storage offer');
+  this._send('getStorageOffer', [contract.toObject()], callback);
 };
 
 /**
  * Proxy RenterInterface#getStorageProof
  */
 RenterPool.prototype.getStorageProof = function(farmer, item, callback) {
+  log.info('[renterpool] getting storage proof');
   this._send('getStorageProof', [farmer, item], callback);
 };
 
@@ -62,7 +62,9 @@ RenterPool.prototype.getStorageProof = function(farmer, item, callback) {
  * Proxy RenterInterface#getConsignToken
  */
 RenterPool.prototype.getConsignToken = function(f, c, a, callback) {
-  this._send('getConsignToken', [f, c.toObject(), {
+  log.info('[renterpool] getting consign token');
+  //const contract = JSON.parse(c);
+  this._send('getConsignToken', [f, c, {
     challenges: a.getPrivateRecord().challenges,
     tree: a.getPublicRecord()
   }], callback);
@@ -72,6 +74,8 @@ RenterPool.prototype.getConsignToken = function(f, c, a, callback) {
  * Proxy RenterInterface#getRetrieveToken
  */
 RenterPool.prototype.getRetrieveToken = function(farmer, contract, callback) {
+  console.trace('POOL', farmer, contract);
+  log.info('[renterpool] getting retrieve token');
   this._send('getRetrieveToken', [farmer, contract.toObject()], callback);
 };
 
@@ -79,6 +83,7 @@ RenterPool.prototype.getRetrieveToken = function(farmer, contract, callback) {
  * Asks a minion for her connected contacts
  */
 RenterPool.prototype.getConnectedContacts = function(callback) {
+  log.info('[renterpool] getting connected contacts');
   this._send('_getConnectedContacts', [], callback);
 };
 
@@ -87,6 +92,7 @@ RenterPool.prototype.getConnectedContacts = function(callback) {
  * @private
  */
 RenterPool.prototype._killall = function(exit, err) {
+  log.warn('[renterpool] killing minions');
   for (let id in this._minions) {
     this._minions[id].kill();
   }
@@ -115,16 +121,13 @@ RenterPool.prototype._forkMinions = function() {
     return setImmediate(_onReady);
   }
 
+  let minionCount = 0;
   async.each(this._options.minions, function(config, done) {
-    log.info('forking renter minion process');
+    log.info('[renterpool] forking renter minion process', minionCount);
 
-    let keypair = storj.KeyPair(config.privkey);
-    let nodeId = keypair.getNodeID();
     let minion = childproc.fork('./bin/minion.js', [JSON.stringify(config)], {
       stdio: 'inherit'
     });
-
-    self._keys[nodeId] = keypair.getPrivateKey();
 
     minion.once('message', function(msg) {
       if (msg === 'ready') {
@@ -132,9 +135,10 @@ RenterPool.prototype._forkMinions = function() {
       }
     });
 
-    self._setupIpcListeners(nodeId, minion);
+    self._setupIpcListeners(minionCount.toString(), minion);
 
-    self._minions[nodeId] = minion;
+    self._minions[minionCount.toString()] = minion;
+    minionCount++;
   }, _onReady);
 };
 
@@ -144,20 +148,16 @@ RenterPool.prototype._forkMinions = function() {
  * @param {String} nodeId
  * @param {ChildProcess} proc
  */
-RenterPool.prototype._setupIpcListeners = function(nodeId, proc) {
+RenterPool.prototype._setupIpcListeners = function(minionNumber, proc) {
   var self = this;
 
   proc.on('error', function(err) {
-    log.error('renter minion %s encountered an error: %s', nodeId, err.message);
+    log.error('[renterpool] renter minion %s encountered an error: %s', minionNumber, err.message);
   });
 
   proc.on('exit', function() {
-    log.error('renter minion %s exited', nodeId);
-    self._replaceMinion(nodeId);
-  });
-
-  proc.on('message', function(message) {
-    self._processMessage(nodeId, message);
+    log.error('[renterpool] renter minion %s exited', minionNumber);
+    self._replaceMinion(minionNumber);
   });
 };
 
@@ -166,24 +166,20 @@ RenterPool.prototype._setupIpcListeners = function(nodeId, proc) {
  * @private
  * @param {String} nodeId
  */
-RenterPool.prototype._replaceMinion = function(nodeId) {
-  this._minions[nodeId].kill();
+RenterPool.prototype._replaceMinion = function(minionNumber) {
+  this._minions[minionNumber].kill();
 
-  log.info('attempting to replace minion %s', nodeId);
+  log.info('[renterpool] attempting to replace minion %s', minionNumber);
 
-  for (let opts in this._options.minions) {
-    if (storj.KeyPair(this._options.minions.privkey).getNodeID() === nodeId) {
-      log.info('replacing minion %s', nodeId);
+  log.info('[renterpool] replacing minion %s', minionNumber);
 
-      let minion = childproc.fork('./bin/minion.js', [
-        JSON.stringify(this._options.minions[opts])
-      ], { stdio: 'inherit' });
+  let minion = childproc.fork('./bin/minion.js', [
+    JSON.stringify(this._options.minions[minionNumber])
+  ], { stdio: 'inherit' });
 
-      this._setupIpcListeners(nodeId, minion);
+  this._setupIpcListeners(minionNumber, minion);
 
-      this._minions[nodeId] = minion;
-    }
-  }
+  this._minions[minionNumber] = minion;
 };
 
 /**
@@ -192,62 +188,22 @@ RenterPool.prototype._replaceMinion = function(nodeId) {
  * @param {String} nodeId
  * @param {Object} message
  */
-RenterPool.prototype._processMessage = function(nodeId, message) {
-  if (!this._pendingCallbacks[message.id]) {
+RenterPool.prototype._processMessage = function(msg) {
+  log.info(`Attempting to process message with correlationId ${msg.properties.correlationId}`);
+  if (!this._pendingCallbacks[msg.properties.correlationId]) {
+    log.warn(`Not processing message with correlationId ${msg.properties.correlationId}`);
     return false;
   }
+  const message = JSON.parse(msg.content.toString());
+  log.info(`Processing message with correlationId ${msg.properties.correlationId}`);
+  let args = message.error ? [] : message.result;
 
-  let args = message.error ? [] : this._castArguments(message).result;
-
-  this._pendingCallbacks[message.id].callback.apply(
+  this._pendingCallbacks[msg.properties.correlationId].callback.apply(
     this,
     message.error ? [new Error(message.error.message)] : args
   );
 
-  delete this._pendingCallbacks[message.id];
-};
-
-/**
- * Cast arguments to appropriate types
- * @private
- */
-RenterPool.prototype._castArguments = function(message) {
-  let method = this._pendingCallbacks[message.id].method;
-
-  switch (method) {
-    case 'getStorageOffer':
-      message.result[0] = storj.Contact(message.result[0]);
-      message.result[1] = storj.Contract.fromJSON(message.result[1]);
-      break;
-    case 'getStorageProof':
-      break;
-    case 'getRetrieveToken':
-      break;
-    case 'getConsignToken':
-      break;
-    default:
-      // noop
-  }
-
-  return message;
-};
-
-/**
- * Plucks the next renter minion in the pool
- * @private
- * @returns {ChildProcess}
- */
-RenterPool.prototype._pluck = function() {
-  var minionIds = Object.keys(this._minions);
-
-  if (this._lastMinionIndex === minionIds.length) {
-    this._lastMinionIndex = 0;
-  }
-
-  return [
-    this._minions[Object.keys(this._minions)[this._lastMinionIndex]],
-    Object.keys(this._minions)[this._lastMinionIndex++]
-  ];
+  delete this._pendingCallbacks[msg.properties.correlationId];
 };
 
 /**
@@ -256,27 +212,21 @@ RenterPool.prototype._pluck = function() {
  * @private
  * @param {String} method
  * @param {Array} params
- * @param {String} nodeId
  * @param {Function} callback
  */
-RenterPool.prototype._send = function(method, params, nodeId, callback) {
-  let proc = null;
-
-  if (typeof nodeId === 'function') {
-    proc = this._pluck()[0];
-    callback = nodeId;
-  } else {
-    proc = this._minions[nodeId];
-  }
-
+RenterPool.prototype._send = function(method, params, callback) {
   let id = hat();
   this._pendingCallbacks[id] = { method: method, callback: callback };
 
-  proc.send({
-    id: id,
-    method: method,
-    params: params
-  });
+  const message = JSON.stringify({ method: method, params: params });
+  return this.messaging.send(
+    message,
+    this.messaging.queues.renterpool,
+    {
+      messageId: id,
+      replyTo: this.messaging.queues.callback
+    }
+  );
 };
 
 module.exports = RenterPool;

--- a/lib/network/pool.js
+++ b/lib/network/pool.js
@@ -74,7 +74,6 @@ RenterPool.prototype.getConsignToken = function(f, c, a, callback) {
  * Proxy RenterInterface#getRetrieveToken
  */
 RenterPool.prototype.getRetrieveToken = function(farmer, contract, callback) {
-  console.trace('POOL', farmer, contract);
   log.info('[renterpool] getting retrieve token');
   this._send('getRetrieveToken', [farmer, contract.toObject()], callback);
 };

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -288,8 +288,6 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
   const Bucket = this.storage.models.Bucket;
   const BucketEntry = this.storage.models.BucketEntry;
 
-  console.log('GOT HERE');
-
   Bucket.findOne({
     user: req.user._id,
     _id: req.params.id
@@ -369,8 +367,6 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
 
           let farmer = new storj.Contact(contact);
           let contract = item.contracts[farmer.nodeID];
-
-          console.log('BUCKETS', farmer, contract);
 
           self.network.getRetrieveToken(farmer, contract, function(err, res) {
             if (err) {

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -288,6 +288,8 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
   const Bucket = this.storage.models.Bucket;
   const BucketEntry = this.storage.models.BucketEntry;
 
+  console.log('GOT HERE');
+
   Bucket.findOne({
     user: req.user._id,
     _id: req.params.id
@@ -367,6 +369,8 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
 
           let farmer = new storj.Contact(contact);
           let contract = item.contracts[farmer.nodeID];
+
+          console.log('BUCKETS', farmer, contract);
 
           self.network.getRetrieveToken(farmer, contract, function(err, res) {
             if (err) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "sinon": "^1.17.2"
   },
   "dependencies": {
+    "amqplib": "^0.4.2",
     "async": "^1.5.2",
     "basic-auth": "^1.0.3",
     "concat-stream": "^1.5.1",

--- a/test/engine.unit.js
+++ b/test/engine.unit.js
@@ -50,7 +50,7 @@ describe('Engine', function() {
       config.network.port = 6484;
       var engine = new Engine(config);
       engine.start(function(err) {
-        expect(err).to.equal(undefined);
+        expect(err).to.equal(null);
         expect(engine.storage).to.be.instanceOf(Storage);
         expect(engine.mailer).to.be.instanceOf(Mailer);
         expect(engine.network).to.be.instanceOf(RenterPool);


### PR DESCRIPTION
The integration tests do not cover this fully, since there is only 1 farmer. We need to test this on staging and confirm that it works with a larger number of farmers before shipping.

Currently there is a bit of code in minion.js that does not get executed. Since that code is the main reason for this change, we need to make sure it works. There may be some remaining issue with serialization of data into rabbitmq that need to be revealed.

Note: This requires a rabbitmq server or cluster. See config.

* Close #98