### PR TITLE
Vagrant provisioner fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Access the [Storj](http://storj.io) network via simple REST API.
 Quick Start
 -----------
 
-With Vagrant
+With Vagrant (Virtual Machine - Windows/Linux/OSX host)
 ============
 
 Download and install [vagrant](https://www.vagrantup.com/downloads.html) for your platform.
@@ -31,14 +31,41 @@ vagrant up
 _NOTE: the first time you `vagrant up` it will take a while as vagrant downloads the base VM and provisions it._
 
 
-SSH into the vm and start the server (set the `NODE_ENV` environment variable to specify the config):
+SSH into the vm and start the server and/or dev farmers:
 
 ```
 vagrant ssh
-NODE_ENV=develop storj-bridge
+# ...
+######################################################################
+###       To start bridge-api-server in development mode run:      ###
+###                    NODE_ENV=develop storj-bridge               ###
+###                                                                ###
+### To start bridge-api-server AND farmers in development mode run: ###
+###                         npm run develop                        ###
+######################################################################
 ```
 
-#### Running node server on host with mongo and rabbitmq on guest
+### The virtual network
+
+Using the default configuration (you havn't modified the `Vagrantfile` in this repo), the VM has 2 network interfaces:
+
++ a NAT interface:
+  
+  This adapter uses NAT to route to the host network and to the internet. Port forwarding is the only way to access the VM from the host network.
++ a host-only interface:
+
+  This adapter connects the VM (*and* the host via its own virtual network adapter) to a virtual switch but does not allow routing to any other networks.
+  This allows the host and the VM to talk to each other without via their respective IP addresses on this virtual network without the need for port forwarding and therefore, without binding up ports on your host.
+  The default IP address of the VM is `172.17.200.10`.
+  
+These two interfaces combined allow the host to talk to the VM on any port by IP as well as allowing the host to access ports on the VM with the hostname `localhost` for any ports that have been forwarded.
+To change which ports are being forwarded, to modify the host-only adapter's IP, or to effect any other networking changes, have a look at the `Vagrantfile` between lines 22-47.
+
+_For additional information regarding vagrant and networking see [vagrant's docs](https://www.vagrantup.com/docs/networking/)_
+
+_For additional information regarding virtualbox (the default vagrant VM provider) networking see [virtualbox's docs](https://www.virtualbox.org/manual/ch06.html)_
+
+### Running node server on host with mongo and rabbitmq on guest
 It is also possible to run the node server on your host but still wish to use the VM for mongo and rabbitmq.
 You may want to so this so you can remotely debug using an IDE running on the host 
 or connect other host-borne tools to these services, for example.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,8 @@ Vagrant.configure("2") do |config|
   # using a specific IP.
   # config.vm.network "private_network", ip: "192.168.33.10"
 
+  config.vm.network "private_network", ip: "172.17.200.10"
+
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
   # your network.
@@ -67,6 +69,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
+    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
   # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,10 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you are using for more
   # information on available options.
 
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+
   # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
   # such as FTP and Heroku are also available. See the documentation at
   # https://docs.vagrantup.com/v2/push/atlas.html for more information.

--- a/ansible/files/motd
+++ b/ansible/files/motd
@@ -1,5 +1,7 @@
-################################################
-### To start bridge in development mode run: ###
-###                                          ###
-###      NODE_ENV=develop storj-bridge       ###
-################################################
+######################################################################
+###       To start bridge-api-server in development mode run:      ###
+###                    NODE_ENV=develop storj-bridge               ###
+###                                                                ###
+### To start bridge-api-sever AND farmers in development mode run: ###
+###                         npm run develop                        ###
+######################################################################

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,13 +3,14 @@
   vars:
     # TODO: lookup synced_dir from Vagrantfile
     synced_dir: /vagrant
-    npm:
-      # TODO: lookup bin name(s) from package.json
-      bin: storj-bridge
     nvm:
       install_script: '{{ synced_dir }}/ansible/roles/node/files/nvm-v0.30.1-install.sh'
       node:
         version: "{{ lookup('file', synced_dir + '/.nvmrc') }}"
+    npm:
+      # TODO: lookup bin name(s) from package.json
+      bin: storj-bridge
+      path: '{{ ansible_env.HOME }}/.nvm/versions/node/v{{ nvm.node.version }}/bin/npm'
   pre_tasks:
     - name: Install service-level dependencies
       become: true
@@ -51,6 +52,7 @@
     - name: 'Install bridge project dependencies (npm install) - NOTE: THIS COULD TAKE A WHILE...'
       npm:
         path: '{{ synced_dir }}'
+        executable: '{{ npm.path }}'
       tags:
         - npm
         - install

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
-- name: Remove any carraige returns in nvm install script (windows + git = carraige returns)
-  local_action:
-    replace:
-      dest: '{{ nvm.install_script }}'
-      regexp: '\r'
+- name: 'Remove any carraige returns in nvm install script (windows + git = carraige returns)'
+  replace:
+    dest: '{{ nvm.install_script }}'
+    regexp: '\r'
 
 - name: Set execute mode on nvm install script
   file:
@@ -19,7 +18,7 @@
   tags:
     - nvm
 
-- name: Source nvm in ~/.profile
+- name: Add source nvm to ~/.profile
   lineinfile:
     dest: ~/.profile
     line: 'source ~/.nvm/nvm.sh'

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Remove any carraige returns in nvm install script (windows + git = carraige returns)
+  local_action:
+    replace:
+      dest: '{{ nvm.install_script }}'
+      regexp: '\r'
+
 - name: Set execute mode on nvm install script
   file:
     path: '{{ nvm.install_script }}'


### PR DESCRIPTION
- [x] Git on windows often likes to add carriage returns. This is a problem for shell scripts so I just added a task that strips `\r`s from the nvm install script.

  **Added a task to strip `\r`s**
- [x] `npm` isn't being sourced after it's installed in the same provisioning run.

  **Use npm ansible module's `executable` option**
- [x] windows doesn't like symlinks in shared directory

  **Add weird config option to vagrant file to make windows ~~suck less~~ work (in this case)**
- [x] it's inconvenient to connect to farmers on the VM

  **Add host-only adapter to provide VM access via IP**
- [x] sometimes `npm i` fails saying `Killed` due to not enough memory

  **Up VM memory to 1GB from 500MB**