### PR TITLE
Fix windows+git+.sh scripts - actually

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: 'Remove any carraige returns in nvm install script (windows + git = carraige returns)'
-  replace:
-    dest: '{{ nvm.install_script }}'
-    regexp: '\r'
-
 - name: Set execute mode on nvm install script
   file:
     path: '{{ nvm.install_script }}'


### PR DESCRIPTION
use .gitattributes instead of ansible task to ensure .sh files are executable when giting on windows: thanks @wilbown