### PR TITLE
Fix `NODE_ENV` and add `CONTACT_IP` env vars:

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,18 @@ vagrant ssh
 ###       To start bridge-api-server in development mode run:      ###
 ###                    NODE_ENV=develop storj-bridge               ###
 ###                                                                ###
-### To start bridge-api-server AND farmers in development mode run: ###
+### To start bridge-api-sever AND farmers in development mode run: ###
+###                    (requires port forwarding)                  ###
 ###                         npm run develop                        ###
+###                                                                ###
+### To start bridge-api-sever AND farmers in development mode run: ###
+###                      (use host-only adapter)                   ###
+###            CONTACT_IP=172.17.200.10 npm run develop            ###
 ######################################################################
 ```
+
+_NOTE: if you need to contact the farmers (or renters/minions) on the VM you may use the `CONTACT_IP` environment variable to tell those processes what IP to provide in their `"address"` property_
+_(e.g.: `{"protocol":"0.7.1","address":"172.17.200.10","port":4001,"nodeID":"b9ddac03c26973b296bb0e2d82e22bd9740fcd60","lastSeen":1469149544291}`)_
 
 ### The virtual network
 

--- a/ansible/files/motd
+++ b/ansible/files/motd
@@ -3,5 +3,10 @@
 ###                    NODE_ENV=develop storj-bridge               ###
 ###                                                                ###
 ### To start bridge-api-sever AND farmers in development mode run: ###
+###                    (requires port forwarding)                  ###
 ###                         npm run develop                        ###
+###                                                                ###
+### To start bridge-api-sever AND farmers in development mode run: ###
+###                      (use host-only adapter)                   ###
+###            CONTACT_IP=172.17.200.10 npm run develop            ###
 ######################################################################

--- a/bin/minion.js
+++ b/bin/minion.js
@@ -5,11 +5,11 @@ const logger = require('../lib/logger');
 const Storage = require('../lib/storage');
 const MongoAdapter = require('../lib/storage/adapter');
 const Config = require('../lib/config');
-const config = Config(process.env.NODE_ENV || 'devel');
+const config = Config(process.env.NODE_ENV || 'develop');
 const Messaging = require('../lib/messaging');
 const messaging = new Messaging(config.messaging);
 
-if (process.env.NODE_ENV === 'devel') {
+if (process.env.NODE_ENV === 'develop') {
   config.storage.name = '__storj-bridge-develop';
 }
 

--- a/bin/storj-bridge.js
+++ b/bin/storj-bridge.js
@@ -5,7 +5,7 @@
 const Config = require('../lib/config');
 const Engine = require('../lib/engine');
 
-module.exports = Engine(Config(process.env.NODE_ENV || 'devel'));
+module.exports = Engine(Config(process.env.NODE_ENV || 'develop'));
 
 module.exports.start(function(err) {
   if (err) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -66,7 +66,7 @@ Config.DEFAULTS = {
   storage: {
     host: '127.0.0.1',
     port: 27017,
-    name: '__storj-bridge-test',
+    name: `__storj-bridge-${process.env.NODE_ENV || 'develop'}`,
     user: null,
     pass: null,
     mongos: false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coverage": "STORJ_ALLOW_LOOPBACK=1 NODE_ENV=test ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --recursive",
     "linter": "./node_modules/.bin/jshint --config .jshintrc ./index.js ./lib ./test",
     "test": "npm run testsuite && npm run linter",
-    "develop": "STORJ_ALLOW_LOOPBACK=1 NODE_ENV=devel node script/develop.js start",
+    "develop": "STORJ_ALLOW_LOOPBACK=1 NODE_ENV=develop node script/develop.js start",
     "make-docs": "./node_modules/.bin/jsdoc index.js lib -r -R README.md -u ./doc -c .jsdoc.json --verbose -d ./jsdoc",
     "publish-docs": "npm run make-docs && node script/publishdoc.js"
   },

--- a/script/develop.js
+++ b/script/develop.js
@@ -44,7 +44,7 @@ var FARMERS = [
 var MINIONS = [
   {
     privkey: privkey,
-    address: '127.0.0.1',
+    address: process.env.CONTACT_IP || '127.0.0.1',
     port: 6383,
     noforward: true,
     tunport: 6483,
@@ -52,7 +52,7 @@ var MINIONS = [
   },
   {
     privkey: privkey,
-    address: '127.0.0.1',
+    address: process.env.CONTACT_IP || '127.0.0.1',
     port: 6384,
     noforward: true,
     tunport: 6484,
@@ -60,10 +60,10 @@ var MINIONS = [
   }
 ];
 
-if (process.env.NODE_ENV === 'devel') {
+if (process.env.NODE_ENV === 'develop') {
   MINIONS.push({
     privkey: privkey,
-    address: '127.0.0.1',
+    address: process.env.CONTACT_IP || '127.0.0.1',
     port: 6385,
     noforward: true,
     tunport: 6485,
@@ -71,12 +71,12 @@ if (process.env.NODE_ENV === 'devel') {
   });
 }
 
-const STORAGE_PATH = process.env.NODE_ENV === 'devel' ?
+const STORAGE_PATH = process.env.NODE_ENV === 'develop' ?
                      path.join(os.tmpdir(), 'storj-bridge-develop') :
                      path.join(os.tmpdir(), 'storj-bridge-test');
 
 FARMERS.forEach(function(farmer) {
-  if (process.env.NODE_ENV !== 'devel') {
+  if (process.env.NODE_ENV !== 'develop') {
     if (fs.existsSync(STORAGE_PATH + '-' + farmer.key)) {
       rimraf.sync(STORAGE_PATH + '-' + farmer.key);
     }
@@ -91,7 +91,7 @@ var config = Config({
   storage: {
     host: '127.0.0.1',
     port: 27017,
-    name: process.env.NODE_ENV === 'devel' ?
+    name: process.env.NODE_ENV === 'develop' ?
           '__storj-bridge-develop' :
           Config.DEFAULTS.storage.name
   },
@@ -116,7 +116,7 @@ var config = Config({
 });
 
 module.exports = function start(callback) {
-  if (process.env.NODE_ENV === 'devel') {
+  if (process.env.NODE_ENV === 'develop') {
     console.log('Storj Bridge in DEVELOP mode with configuration:');
     console.log('');
     console.log(config);
@@ -132,7 +132,7 @@ module.exports = function start(callback) {
     // Set up Storj Farmer
     var farmer = storj.FarmerInterface({
       keypair: storj.KeyPair(key),
-      address: '127.0.0.1',
+      address: process.env.CONTACT_IP || '127.0.0.1',
       storage: {
         path: STORAGE_PATH + '-' + key,
         size: 10,


### PR DESCRIPTION
+ Use `develop` consistently as the development value for the `NODE_ENV` environment variable
+ Add `CONTACT_IP` env var to allow for reply-to addresses of minions/renters and farmers to refer to alternate interfaces' IPs (e.g.: the host-only adapter of the vagrant VM)