### PR TITLE
[WIP] Features/BridgeClient API by name

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -178,7 +178,7 @@ BucketsRouter.prototype.updateBucketById = function(req, res, next) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
-    var allowed = ['storage', 'transfer', 'name', 'pubkeys'];
+    var allowed = ['storage', 'transfer', 'pubkeys'];
 
     for (let prop in req.body) {
       if (allowed.indexOf(prop) !== -1) {

--- a/lib/storage/models/bucket.js
+++ b/lib/storage/models/bucket.js
@@ -60,7 +60,8 @@ Bucket.set('toObject', {
 Bucket.statics.create = function(user, data, callback) {
   let Bucket = this;
 
-  data.name = data.name ? data.name : 'xxxxxxxx'.replace(/x/g, function() {
+  // make default name a random hex string
+  data.name = data.name !== undefined ? data.name : 'xxxxxxxx'.replace(/x/g, function() {
     var num = Math.floor(Math.random() * 16);
     return num.toString(16);
   });

--- a/lib/storage/models/bucket.js
+++ b/lib/storage/models/bucket.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const storj = require('storj');
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 
@@ -66,6 +67,9 @@ Bucket.statics.create = function(user, data, callback) {
     pubkeys: data.pubkeys,
     user: user._id
   });
+
+  var bucketId = storj.utils.calculateBucketId( bucket.user, bucket.name );
+  bucket._id = mongoose.Types.ObjectId(bucketId);
 
   bucket.save(function(err) {
     if (err) {

--- a/lib/storage/models/bucket.js
+++ b/lib/storage/models/bucket.js
@@ -60,6 +60,12 @@ Bucket.set('toObject', {
 Bucket.statics.create = function(user, data, callback) {
   let Bucket = this;
 
+  // reject name if it is valid bucket id
+  var re = /[0-9A-Fa-f]{24}/g;
+  if(re.test(data.name)){
+    return callback(new Error('Name cannot be 24 character hex'));
+  }
+
   // make default name a random hex string
   data.name = data.name !== undefined ? data.name : 'xxxxxxxx'.replace(/x/g, function() {
     var num = Math.floor(Math.random() * 16);

--- a/lib/storage/models/bucket.js
+++ b/lib/storage/models/bucket.js
@@ -59,6 +59,12 @@ Bucket.set('toObject', {
  */
 Bucket.statics.create = function(user, data, callback) {
   let Bucket = this;
+
+  data.name = data.name ? data.name : 'xxxxxxxx'.replace(/x/g, function() {
+    var num = Math.floor(Math.random() * 16);
+    return num.toString(16);
+  });
+
   let bucket = new Bucket({
     storage: data.storage,
     transfer: data.transfer,
@@ -73,6 +79,9 @@ Bucket.statics.create = function(user, data, callback) {
 
   bucket.save(function(err) {
     if (err) {
+      if (err.message.indexOf('duplicate key') !== -1) {
+        return callback(new Error('Name already used by another bucket'));
+      }
       return callback(err);
     }
 

--- a/lib/storage/models/bucket.js
+++ b/lib/storage/models/bucket.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const storj = require('storj');
+const crypto = require('crypto');
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 
@@ -75,8 +75,10 @@ Bucket.statics.create = function(user, data, callback) {
     user: user._id
   });
 
-  var bucketId = storj.utils.calculateBucketId(bucket.user, bucket.name);
-  bucket._id = mongoose.Types.ObjectId(bucketId);
+  // calculate bucket id by taking first 12 bytes of sha256(user id + bucket name)
+  var hashInput = user._id + data.name;
+  var bucketHash = crypto.createHash('sha256').update(hashInput, 'utf8').digest('hex');
+  bucket._id = mongoose.Types.ObjectId(bucketHash.substring(0, 24));
 
   bucket.save(function(err) {
     if (err) {

--- a/lib/storage/models/bucket.js
+++ b/lib/storage/models/bucket.js
@@ -75,7 +75,7 @@ Bucket.statics.create = function(user, data, callback) {
     user: user._id
   });
 
-  var bucketId = storj.utils.calculateBucketId( bucket.user, bucket.name );
+  var bucketId = storj.utils.calculateBucketId(bucket.user, bucket.name);
   bucket._id = mongoose.Types.ObjectId(bucketId);
 
   bucket.save(function(err) {

--- a/test/engine.integration.js
+++ b/test/engine.integration.js
@@ -258,6 +258,17 @@ describe('Engine/Integration', function() {
         });
       });
 
+      it('should reject a duplicate name', function(done) {
+        client.createBucket({
+          name: 'Test Bucket'
+        }, function(err) {
+          expect(err.message).to.equal(
+            'Name already used by another bucket'
+          );
+          done();
+        });
+      });
+
       it('should reject an invalid ecdsa key', function(done) {
         client.createBucket({
           name: 'Test Bucket invalid ecdsa key',
@@ -301,9 +312,9 @@ describe('Engine/Integration', function() {
       it('should update the bucket information', function(done) {
         client.getBuckets(function(err, buckets) {
           client.updateBucketById(buckets[0].id, {
-            name: 'My App Name'
+            storage: 10
           }, function(err, bucket) {
-            expect(bucket.name).to.equal('My App Name');
+            expect(bucket.storage).to.equal(10);
             done();
           });
         });
@@ -312,7 +323,6 @@ describe('Engine/Integration', function() {
       it('should update the bucket information', function(done) {
         client.getBuckets(function(err, buckets) {
           client.updateBucketById(buckets[0].id, {
-            name: 'Test Bucket invalid ecdsa key',
             pubkeys: [ 'testkey' ]
           }, function(err) {
             expect(err.message).to.equal(

--- a/test/engine.integration.js
+++ b/test/engine.integration.js
@@ -312,9 +312,9 @@ describe('Engine/Integration', function() {
       it('should update the bucket information', function(done) {
         client.getBuckets(function(err, buckets) {
           client.updateBucketById(buckets[0].id, {
-            storage: 10
+            storage: 3
           }, function(err, bucket) {
-            expect(bucket.storage).to.equal(10);
+            expect(bucket.storage).to.equal(3);
             done();
           });
         });

--- a/test/storage/bucket.unit.js
+++ b/test/storage/bucket.unit.js
@@ -32,7 +32,7 @@ describe('Storage/models/Bucket', function() {
   describe('#create', function() {
 
     it('should create the bucket with the default props', function(done) {
-      Bucket.create({ _id: 'user@domain.tld' }, {}, function(err, bucket) {
+      Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket' }, function(err, bucket) {
         expect(err).to.not.be.instanceOf(Error);
         expect(bucket.storage).to.equal(10);
         expect(bucket.transfer).to.equal(30);
@@ -84,7 +84,6 @@ describe('Storage/models/Bucket', function() {
           expect(bucket.storage).to.equal(10);
           expect(bucket.transfer).to.equal(30);
           expect(bucket.status).to.equal('Active');
-          expect(bucket.name).to.equal('New Bucket');
           expect(bucket.pubkeys[0]).to.equal(publicKey1);
           expect(bucket.pubkeys[1]).to.equal(publicKey2);
           expect(bucket.user).to.equal('user@domain.tld');
@@ -106,7 +105,6 @@ describe('Storage/models/Bucket', function() {
           expect(bucket.storage).to.equal(10);
           expect(bucket.transfer).to.equal(30);
           expect(bucket.status).to.equal('Active');
-          expect(bucket.name).to.equal('New Bucket');
           expect(bucket.pubkeys[0]).to.equal(publicKey);
           expect(bucket.pubkeys[1]).to.equal(publicKey);
           expect(bucket.user).to.equal('user@domain.tld');

--- a/test/storage/bucket.unit.js
+++ b/test/storage/bucket.unit.js
@@ -113,6 +113,15 @@ describe('Storage/models/Bucket', function() {
       });
     });
 
+    it('should reject the bucket with 24 character hex name', function(done) {
+      Bucket.create({ _id: 'user@domain.tld' }, {
+        name: '0123456789ab0123456789ab'
+      }, function(err) {
+        expect(err.message).to.equal('Name cannot be 24 character hex');
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
The bridge aspect for implementing #186 using the method I suggested. The possible deal-breaker for using this method is that bucket name can not be changed after it is created. This will change the bridge client api of course.

Benefits to this method:
  * Does not require a list-buckets call to use bucket name in any bridge API call
  * Bucket names together with an email address can be used to form the unique bucket id
  * Duplicate buckets won't be created since they will cause a duplicate id error

Issues with this method:
  * Can no longer change bucket name since it is tied to the bucket id. This requires a change in the BridgeClient and core-cli's update-bucket code.
  * Cannot create multiple buckets with same name for same user, this means some of the test cases will had to be rewritten
  * This method will only work for newly created buckets with bucket id's following the format sha256(userId + bucketName)
  * Default bucket name is now a random hex string instead of 'New Bucket' to avoid accidental duplicates
  * Doesn't allow bucket name to be 24 character hex since that would make it ambigious whether user was reffering to name or id