### PR TITLE
Deterministic Id handling changes

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -318,7 +318,7 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
         bucket: bucket._id,
         frame: frame._id,
         mimetype: req.body.mimetype,
-        name: req.body.filename
+        filename: req.body.filename
       }, function(err, entry) {
         if (err) {
           return next(new errors.InternalError(err.message));

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -318,7 +318,7 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
         bucket: bucket._id,
         frame: frame._id,
         mimetype: req.body.mimetype,
-        filename: req.body.filename
+        name: req.body.filename
       }, function(err, entry) {
         if (err) {
           return next(new errors.InternalError(err.message));

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -175,7 +175,7 @@ BucketsRouter.prototype.updateBucketById = function(req, res, next) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
-    var allowed = ['name', 'pubkeys'];
+    var allowed = ['pubkeys'];
 
     for (let prop in req.body) {
       if (allowed.indexOf(prop) !== -1) {
@@ -314,14 +314,12 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
         return next(new errors.BadRequestError('Frame is already locked'));
       }
 
-      let entry = new BucketEntry({
+      BucketEntry.create({
         bucket: bucket._id,
         frame: frame._id,
         mimetype: req.body.mimetype,
         name: req.body.filename
-      });
-
-      entry.save(function(err) {
+      }, function(err, entry) {
         if (err) {
           return next(new errors.InternalError(err.message));
         }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "storj-service-error-types": "^1.0.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.0.0",
-    "storj-service-storage-models": "^1.0.0",
+    "storj-service-storage-models": "^2.1.3",
     "through": "^2.3.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "storj-service-error-types": "^1.0.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.0.0",
-    "storj-service-storage-models": "^2.1.3",
+    "storj-service-storage-models": "^2.1.4",
     "through": "^2.3.8"
   }
 }

--- a/test/routes/buckets.unit.js
+++ b/test/routes/buckets.unit.js
@@ -56,7 +56,7 @@ describe('BucketRoutes', function() {
           bucket: bucketId,
           frame: frameId,
           mimetype: mimetype,
-          name: fileName
+          filename: fileName
         }, function(err, entry){
           fileId = entry.id.toString();
           callback();

--- a/test/routes/buckets.unit.js
+++ b/test/routes/buckets.unit.js
@@ -56,7 +56,7 @@ describe('BucketRoutes', function() {
           bucket: bucketId,
           frame: frameId,
           mimetype: mimetype,
-          filename: fileName
+          name: fileName
         }, function(err, entry){
           fileId = entry.id.toString();
           callback();


### PR DESCRIPTION
Depends on https://github.com/Storj/core/pull/477 and is part of https://github.com/Storj/core-cli/issues/14 Remove ability to update bucket name (since the bucket name is tied to the bucket id), switch new BucketEntry to BucketEntry.create