### PR TITLE
Feature/public buckets

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -787,7 +787,7 @@ BucketsRouter.prototype.getFileInfo = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
 
   BucketEntry.findOne({
-    _id: req.params.file,
+    _id: req.params.file
   }).populate('frame').exec(function(err, entry) {
     if (err) {
       return next(new errors.InternalError(err.message));

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -5,6 +5,7 @@ const storj = require('storj-lib');
 const middleware = require('storj-service-middleware');
 const authenticate = middleware.authenticate;
 const tokenauth = middleware.tokenauth;
+const publicBucket = middleware.publicBucket;
 const log = require('../../logger');
 const merge = require('merge');
 const errors = require('storj-service-error-types');
@@ -25,6 +26,7 @@ function BucketsRouter(options) {
   Router.apply(this, arguments);
 
   this._verify = authenticate(this.storage);
+  this._isPublic = publicBucket(this.storage);
   this._usetoken = tokenauth(this.storage);
 }
 
@@ -224,25 +226,37 @@ BucketsRouter.prototype.createBucketToken = function(req, res, next) {
     let strategy = authenticate._detectStrategy(req);
     let rawbody = self._verify[0];
     let checkauth = self._verify[1];
+    let isPublic = self._isPublic;
 
     rawbody(req, res, function(err) {
       if (err) {
         return callback(err);
       }
 
-      checkauth(req, res, function(err) {
-        if (err) {
-          if (strategy === 'ECDSA' && authenticate._verifySignature(req)) {
-            query.pubkeys = { $in: [req.header('x-pubkey')] };
-            return callback(null, query);
-          } else {
-            return callback(err);
-          }
+      isPublic(req, res, function(err, publicBucket){
+        if(err){
+          return callback(err);
+        }
+        if(publicBucket){
+          return callback(null, query);
         }
 
-        query.user = req.user._id;
-        return callback(null, query);
+        checkauth(req, res, function(err) {
+          if (err) {
+            if (strategy === 'ECDSA' && authenticate._verifySignature(req)) {
+              query.pubkeys = { $in: [req.header('x-pubkey')] };
+              return callback(null, query);
+            } else {
+              return callback(err);
+            }
+          }
+
+          query.user = req.user._id;
+          return callback(null, query);
+        });
+
       });
+
     });
   }
 

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -283,7 +283,10 @@ BucketsRouter.prototype.createBucketToken = function(req, res, next) {
           return next(new errors.InternalError(err.message));
         }
 
-        res.status(201).send(token.toObject());
+        var token = token.toObject();
+        token.encryptionKey = bucket.encryptionKey;
+
+        res.status(201).send(token);
       });
     });
   });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -283,10 +283,10 @@ BucketsRouter.prototype.createBucketToken = function(req, res, next) {
           return next(new errors.InternalError(err.message));
         }
 
-        var token = token.toObject();
-        token.encryptionKey = bucket.encryptionKey;
+        var tokenObject = token.toObject();
+        tokenObject.encryptionKey = bucket.encryptionKey;
 
-        res.status(201).send(token);
+        res.status(201).send(tokenObject);
       });
     });
   });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -177,7 +177,7 @@ BucketsRouter.prototype.updateBucketById = function(req, res, next) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
 
-    var allowed = ['name', 'pubkeys'];
+    var allowed = ['pubkeys', 'encryptionKey', 'publicPermissions'];
 
     for (let prop in req.body) {
       if (allowed.indexOf(prop) !== -1) {
@@ -233,11 +233,8 @@ BucketsRouter.prototype.createBucketToken = function(req, res, next) {
         return callback(err);
       }
 
-      isPublic(req, res, function(err, publicBucket){
-        if(err){
-          return callback(err);
-        }
-        if(publicBucket){
+      isPublic(req, res, function(err){
+        if(!err){
           return callback(null, query);
         }
 
@@ -790,7 +787,7 @@ BucketsRouter.prototype.getFileInfo = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
 
   BucketEntry.findOne({
-    _id: req.params.file
+    _id: req.params.file,
   }).populate('frame').exec(function(err, entry) {
     if (err) {
       return next(new errors.InternalError(err.message));

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "storj-mongodb-adapter": "^2.0.0",
     "storj-service-error-types": "^1.0.0",
     "storj-service-mailer": "^1.0.0",
-    "storj-service-middleware": "^1.0.0",
+    "storj-service-middleware": "^1.1.0",
     "storj-service-storage-models": "^2.1.3",
     "through": "^2.3.8"
   }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "storj-service-error-types": "^1.0.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.0.0",
-    "storj-service-storage-models": "^2.1.0",
+    "storj-service-storage-models": "^2.1.3",
     "through": "^2.3.8"
   }
 }

--- a/test/routes/buckets.unit.js
+++ b/test/routes/buckets.unit.js
@@ -25,6 +25,8 @@ describe('BucketRoutes', function() {
 
   var bucketId, fileId, frameId, publicBucketId;
   var publicBucketName = 'Public Bucket';
+  var encryptionKey = 'abcdef';
+  var publicPermissions = ['PULL', 'PUSH'];
 
   var initialize = function(done) {
 
@@ -38,7 +40,7 @@ describe('BucketRoutes', function() {
       // create private bucket
       function(callback) {
         models.Bucket.create({
-          user: user
+          _id: user
         },
         {
           pubkeys: [],
@@ -70,7 +72,7 @@ describe('BucketRoutes', function() {
       // create bucket which will be made public
       function(callback){
         models.Bucket.create({
-            user: user
+            _id: user
           },
           {
             pubkeys: [],
@@ -104,7 +106,7 @@ describe('BucketRoutes', function() {
   describe('#updateBucketById', function() {
 
     it('should return internal error message', function(done) {
-      var badBucketId = 'asdf';
+      var badBucketId = '01234567891ab';
       request(app)
         .patch('/buckets/' + badBucketId)
         .auth(user, hashedPassword)
@@ -116,12 +118,78 @@ describe('BucketRoutes', function() {
       });
     });
 
+    it('should reject invalid update', function(done) {
+      request(app)
+        .patch('/buckets/' + publicBucketId)
+        .send({ publicPermissions: ['Invalid'] })
+        .auth(user, hashedPassword)
+        .expect(500)
+        .end(function(err, res) {
+          expect(err).to.equal(null);
+          expect(res.res.statusMessage).to.equal('Internal Server Error');
+          done();
+      });
+    });
+
+    it('should update the bucket permissions and encryptionKey', function(done) {
+      request(app)
+        .patch('/buckets/' + publicBucketId)
+        .send({
+          publicPermissions: publicPermissions,
+          encryptionKey: encryptionKey,
+        })
+        .auth(user, hashedPassword)
+        .expect(200)
+        .end(function(err, res) {
+          expect(err).to.equal(null);
+          var body = res.body;
+          expect(body.publicPermissions).to.include.members(publicPermissions);
+          expect(body.encryptionKey).to.equal(encryptionKey);
+          done();
+      });
+    });
+
   });
 
   describe('#createBucketToken', function() {
 
     it('Should reject due to invalid auth', function(done) {
-      done();
+      request(app)
+        .post('/buckets/' + bucketId + '/tokens')
+        .send({ operation: 'PULL' })
+        .expect(500)
+        .end(function(err, res) {
+          expect(err).to.equal(null);
+          expect(res.res.statusMessage).to.equal('Internal Server Error');
+          done();
+      });
+    });
+
+    it('Should allow access to bucket with auth', function(done) {
+      request(app)
+        .post('/buckets/' + bucketId + '/tokens')
+        .auth(user, hashedPassword)
+        .send({ operation: 'PULL' })
+        .expect(201)
+        .end(function(err, res) {
+          expect(err).to.equal(null);
+          var body = res.body;
+          expect(body.encryptionKey).to.equal('');
+          done();
+      });
+    });
+
+    it('Should allow access to public bucket without auth', function(done) {
+      request(app)
+        .post('/buckets/' + publicBucketId + '/tokens')
+        .send({ operation: 'PULL' })
+        .expect(201)
+        .end(function(err, res) {
+          expect(err).to.equal(null);
+          var body = res.body;
+          expect(body.encryptionKey).to.equal(encryptionKey);
+          done();
+      });
     });
 
   });

--- a/test/routes/buckets.unit.js
+++ b/test/routes/buckets.unit.js
@@ -67,7 +67,7 @@ describe('BucketRoutes', function() {
           callback();
         });
       },
-      // create soon to be public bucket
+      // create bucket which will be made public
       function(callback){
         models.Bucket.create({
             user: user


### PR DESCRIPTION
Add support for public buckets. This depends on the new middleware added here: https://github.com/Storj/service-middleware/pull/5

This modifies updateBucketById so that the permissions and encryptionKey can be changed/added. It adds the isPublicBucket middleware into the createBucketToken authentication. Finally, it makes the returned token include the encryptionKey if one exists.