### PR TITLE
Add bucket id to getFileInfo query

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -785,6 +785,7 @@ BucketsRouter.prototype.getFileInfo = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
 
   BucketEntry.findOne({
+    bucket: req.params.id,
     _id: req.params.file
   }).populate('frame').exec(function(err, entry) {
     if (err) {


### PR DESCRIPTION
This is causing the getFileInfo api requests to fail since we are looking them up by entryId, not the index which is bucket id. The getShares now depends on the getFileInfo api call so that was failing as well. This should be fixed asap.