### PR TITLE
Fix crash when bucket entry not found

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -805,6 +805,10 @@ BucketsRouter.prototype.getFileInfo = function(req, res, next) {
       return next(new errors.InternalError(err.message));
     }
 
+    if (!entry) {
+      return next(new errors.NotFoundError('File not found'));
+    }
+
     res.status(200).send({
       bucket: entry.bucket,
       mimetype: entry.mimetype,


### PR DESCRIPTION
Cannot read property 'bucket' of null at lib/server/routes/buckets.js:813:20