### PR TITLE
Add size and mimetype to token if user supplies file

### DIFF
--- a/lib/apispec.json
+++ b/lib/apispec.json
@@ -1301,6 +1301,10 @@
                 "operation": {
                   "type": "string",
                   "description": "PUSH or PULL operation"
+                },
+                "file": {
+                  "type": "string",
+                  "description": "Optional file ID for retrieving size and mimetype"
                 }
               }
             }
@@ -1331,6 +1335,14 @@
                 "encryptionKey": {
                   "type": "string",
                   "description": "Bucket encryption key if the bucket is public"
+                },
+                "size": {
+                  "type": "string",
+                  "description": "Size of file if file ID is sent as argument"
+                },
+                "mimetype": {
+                  "type": "string",
+                  "description": "Mimetype of file if file ID is sent as argument"
                 }
               }
             }

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -273,6 +273,7 @@ BucketsRouter.prototype._getBucketUnregistered = function(req, res, next) {
  */
 BucketsRouter.prototype.createBucketToken = function(req, res, next) {
   const Token = this.storage.models.Token;
+  const BucketEntry = this.storage.models.BucketEntry;
 
   this._getBucketUnregistered(req, res, function(err, bucket) {
     if (err) {
@@ -288,7 +289,26 @@ BucketsRouter.prototype.createBucketToken = function(req, res, next) {
       var tokenObject = token.toObject();
       tokenObject.encryptionKey = bucket.encryptionKey;
 
-      res.status(201).send(tokenObject);
+      var file = req.body.file;
+      if (!file || req.body.operation !== 'PULL') {
+        res.status(201).send(tokenObject);
+        return;
+      }
+
+      BucketEntry.findOne({
+        _id: file,
+        bucket: bucket._id
+      }).populate('frame').exec(function(err, bucketEntry) {
+        if (err) {
+          return next(err);
+        }
+        if (!bucketEntry) {
+          return next(new errors.NotFoundError('Bucket entry not found'));
+        }
+        tokenObject.mimetype = bucketEntry.mimetype;
+        tokenObject.size = bucketEntry.frame.size;
+        res.status(201).send(tokenObject);
+      });
     });
   });
 };

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -847,6 +847,106 @@ describe('BucketsRouter', function() {
       bucketsRouter.createBucketToken(request, response);
     });
 
+    it('should call next with a database error', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'POST',
+        url: '/buckets/:bucket_id/tokens',
+        body: {
+          operation: 'PULL',
+          file: 'fileid'
+        },
+        params: {
+          id: 'bucketid'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      var _bucket = new bucketsRouter.storage.models.Bucket({
+        name: 'Some Bucket'
+      });
+      var _getBucketUnregistered = sinon.stub(
+        bucketsRouter,
+        '_getBucketUnregistered'
+      ).callsArgWith(2, null, _bucket);
+      var _token = new bucketsRouter.storage.models.Token({
+        bucket: _bucket._id,
+        operation: 'PUSH',
+        _id: bucketsRouter.storage.models.Token.generate()
+      });
+      var _tokenCreate = sinon.stub(
+        bucketsRouter.storage.models.Token,
+        'create'
+      ).callsArgWith(2, null, _token);
+      var _getBucketEntry = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'findOne'
+      ).returns({
+        populate: sinon.stub().returns({
+          exec: sinon.stub().callsArgWith(0, new Error('DB error'))
+        })
+      });
+      bucketsRouter.createBucketToken(request, response, function(err){
+        _tokenCreate.restore();
+        _getBucketUnregistered.restore();
+        _getBucketEntry.restore();
+        expect(err.message).to.equal('DB error');
+        done();
+      });
+    });
+
+    it('should call next with an entry not found error', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'POST',
+        url: '/buckets/:bucket_id/tokens',
+        body: {
+          operation: 'PULL',
+          file: 'fileid'
+        },
+        params: {
+          id: 'bucketid'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      var _bucket = new bucketsRouter.storage.models.Bucket({
+        name: 'Some Bucket'
+      });
+      var _getBucketUnregistered = sinon.stub(
+        bucketsRouter,
+        '_getBucketUnregistered'
+      ).callsArgWith(2, null, _bucket);
+      var _token = new bucketsRouter.storage.models.Token({
+        bucket: _bucket._id,
+        operation: 'PUSH',
+        _id: bucketsRouter.storage.models.Token.generate()
+      });
+      var _tokenCreate = sinon.stub(
+        bucketsRouter.storage.models.Token,
+        'create'
+      ).callsArgWith(2, null, _token);
+      var _getBucketEntry = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'findOne'
+      ).returns({
+        populate: sinon.stub().returns({
+          exec: sinon.stub().callsArgWith(0, null, null)
+        })
+      });
+      bucketsRouter.createBucketToken(request, response, function(err){
+        _tokenCreate.restore();
+        _getBucketUnregistered.restore();
+        _getBucketEntry.restore();
+        expect(err.message).to.equal('Bucket entry not found');
+        done();
+      });
+    });
+
   });
 
   describe('#createEntryFromFrame', function() {

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -789,6 +789,64 @@ describe('BucketsRouter', function() {
       bucketsRouter.createBucketToken(request, response);
     });
 
+    it('should send back file info if file id is supplied', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'POST',
+        url: '/buckets/:bucket_id/tokens',
+        body: {
+          operation: 'PULL',
+          file: 'fileid'
+        },
+        params: {
+          id: 'bucketid'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      var _bucket = new bucketsRouter.storage.models.Bucket({
+        name: 'Some Bucket'
+      });
+      var _getBucketUnregistered = sinon.stub(
+        bucketsRouter,
+        '_getBucketUnregistered'
+      ).callsArgWith(2, null, _bucket);
+      var _token = new bucketsRouter.storage.models.Token({
+        bucket: _bucket._id,
+        operation: 'PUSH',
+        _id: bucketsRouter.storage.models.Token.generate()
+      });
+      var _tokenCreate = sinon.stub(
+        bucketsRouter.storage.models.Token,
+        'create'
+      ).callsArgWith(2, null, _token);
+      var frameSize = 100;
+      var mimetype = 'plain/text';
+      var _getBucketEntry = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'findOne'
+      ).returns({
+        populate: sinon.stub().returns({
+          exec: sinon.stub().callsArgWith(0, null, {
+            frame: { size: frameSize },
+            mimetype: mimetype
+          })
+        })
+      });
+      response.on('end', function() {
+        _tokenCreate.restore();
+        _getBucketUnregistered.restore();
+        _getBucketEntry.restore();
+        var data = response._getData();
+        expect(data.size).to.equal(frameSize);
+        expect(data.mimetype).to.equal(mimetype);
+        done();
+      });
+      bucketsRouter.createBucketToken(request, response);
+    });
+
   });
 
   describe('#createEntryFromFrame', function() {


### PR DESCRIPTION
Supply user with size and mimetype of file when creating bucket token if they are making a bucket PULL and include a valid file id