### PR TITLE
Revert "Create bucket entry with id"

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -356,7 +356,6 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
       BucketEntry.create({
         bucket: bucket._id,
         frame: frame._id,
-        id: req.body.id,
         mimetype: req.body.mimetype,
         name: req.body.filename
       }, function(err, entry) {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "storj-service-error-types": "^1.1.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.2.1",
-    "storj-service-storage-models": "^8.1.0",
+    "storj-service-storage-models": "^8.0.0",
     "through": "^2.3.8"
   }
 }

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -956,8 +956,6 @@ describe('BucketsRouter', function() {
   });
 
   describe('#createEntryFromFrame', function() {
-    const sandbox = sinon.sandbox.create();
-    afterEach(() => sandbox.restore());
 
     it('should internal error if bucket query fails', function(done) {
       var request = httpMocks.createRequest({
@@ -1226,52 +1224,6 @@ describe('BucketsRouter', function() {
         _bucketEntryCreate.restore();
         expect(response._getData().frame).to.equal('frameid');
         expect(response._getData().bucket).to.equal('bucketid');
-        done();
-      });
-      bucketsRouter.createEntryFromFrame(request, response);
-    });
-
-    it('should create entry with id', function(done) {
-      var request = httpMocks.createRequest({
-        method: 'POST',
-        url: '/buckets/:bucket_id/files',
-        body: {
-          frame: 'frameid',
-          id: 'fileid'
-        },
-        params: {
-          id: 'bucketid'
-        }
-      });
-      request.user = someUser;
-      var response = httpMocks.createResponse({
-        req: request,
-        eventEmitter: EventEmitter
-      });
-      sandbox.stub(
-        bucketsRouter.storage.models.Bucket,
-        'findOne'
-      ).callsArgWith(1, null, { _id: 'bucketid' });
-      sandbox.stub(
-        bucketsRouter.storage.models.Frame,
-        'findOne'
-      ).callsArgWith(1, null, {
-        locked: false,
-        lock: sinon.stub().callsArg(0)
-      });
-      var entry = { frame: 'frameid', bucket: 'bucketid', id: 'fileid' };
-      var create = sandbox.stub(
-        bucketsRouter.storage.models.BucketEntry,
-        'create'
-      ).callsArgWith(1, null, {
-        toObject: sinon.stub().returns(entry)
-      });
-      response.on('end', function() {
-        expect(create.callCount).to.equal(1);
-        expect(create.args[0][0].id).to.equal('fileid');
-        expect(response._getData().frame).to.equal('frameid');
-        expect(response._getData().bucket).to.equal('bucketid');
-        expect(response._getData().id).to.equal('fileid');
         done();
       });
       bucketsRouter.createEntryFromFrame(request, response);


### PR DESCRIPTION
Reverts Storj/bridge#349

This change will require a migration from ObjectId to String for bucket entries, and will address later once this is prepared.