### PR TITLE
Slight apispec update

### DIFF
--- a/lib/apispec.json
+++ b/lib/apispec.json
@@ -1417,9 +1417,9 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "hash": {
+                  "id": {
                     "type": "string",
-                    "example": "9c1185a5c5e9fc54612808977ee8f548b2258d31"
+                    "example": "1a3acc12816f09498f52b78f"
                   },
                   "bucket": {
                     "type": "string",
@@ -1436,6 +1436,10 @@
                   "size": {
                     "type": "number",
                     "example": 5071076
+                  },
+                  "frame": {
+                    "type": "string",
+                    "example": "58b5ee30d3366b79b9286eee"
                   }
                 }
               }


### PR DESCRIPTION
`GET /buckets/{id}/files` now returns a list of file metadata objects with an `id` property, rather than a hash property.

Sample response body:
```[{"bucket":"d2372a1f94b0d26d058b2456","mimetype":"image/png","filename":"jq.png","frame":"58b5ee30d3366b79b9286eee","size":5183997,"id":"1a3acc12816f09498f52b78f","hmac":{}}]```