### PR TITLE
Mirror shards when farmers go offline

### DIFF
--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -150,9 +150,14 @@ Monitor.prototype._transferShard = function(shard, state) {
   const source = state.sources[0];
   const destination = state.destinations[0];
 
-  if (!source || !destination) {
+  if (!source) {
     return log.error('Unable to replicate shard %s, reason: %s',
-                     shard.hash, 'Sources and/or destinations exhausted');
+                     shard.hash, 'sources exhausted');
+  }
+
+  if (!destination) {
+    return log.error('Unable to replicate shard %s, reason: %s',
+                     shard.hash, 'destinations exhausted');
   }
 
   let contract = null;

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -67,8 +67,8 @@ Monitor.prototype.start = function(callback) {
 };
 
 Monitor.sortByTimeoutRate = function(a, b) {
-  const a1 = a.contact.timeoutRate >= 0 ? a.contact.timeoutRate : Infinity;
-  const b1 = b.contact.timeoutRate >= 0 ? b.contact.timeoutRate : Infinity;
+  const a1 = a.contact.timeoutRate >= 0 ? a.contact.timeoutRate : 0;
+  const b1 = b.contact.timeoutRate >= 0 ? b.contact.timeoutRate : 0;
   return (a1 === b1) ? 0 : (a1 > b1) ? 1 : -1;
 };
 

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -66,6 +66,12 @@ Monitor.prototype.start = function(callback) {
   process.on('uncaughtException', this._handleUncaughtException.bind(this));
 };
 
+Monitor.sortByTimeoutRate = function(a, b) {
+  const a1 = a.contact.timeoutRate || 0;
+  const b1 = b.contact.timeoutRate || 0;
+  return (a1 === b1) ? 0 : (a1 > b1) ? 1 : -1;
+};
+
 Monitor.prototype._fetchDestinations = function(shard, callback) {
   this.storage.models.Mirror
     .find({ shardHash: shard.hash })
@@ -82,7 +88,7 @@ Monitor.prototype._fetchDestinations = function(shard, callback) {
           return true;
         }
       });
-      // TODO sort by contact.timeoutRate
+      mirrors.sort(Monitor.sortByTimeoutRate);
       callback(null, mirrors);
     });
 };

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -186,7 +186,7 @@ Monitor.prototype._replicateFarmer = function(contact) {
   const query = {
     'contracts.nodeID': contact.nodeID
   };
-  const cursor = this.storage.models.Shard.find(query);
+  const cursor = this.storage.models.Shard.find(query).cursor();
 
   cursor
     .on('error', (err) => {

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -66,52 +66,40 @@ Monitor.prototype.start = function(callback) {
   process.on('uncaughtException', this._handleUncaughtException.bind(this));
 };
 
-Monitor.sortByTimeoutRate = function(a, b) {
-  const aTime = a.contact.timeoutRate || 1;
-  const bTime = b.contact.timeoutRate || 1;
-  return (aTime === bTime) ? 0 : (aTime < bTime) ? 1 : -1;
-};
-
-Monitor.sortByLastSeen = function(a, b) {
-  const aTime = a.contact.lastSeen || 0;
-  const bTime = b.contact.lastSeen || 0;
-  return (aTime === bTime) ? 0 : (aTime > bTime) ? 1 : -1;
-};
-
 Monitor.prototype._fetchDestinations = function(shard, callback) {
-  this.storage.models.Mirror.find({ shardHash: shard.hash })
+  this.storage.models.Mirror
+    .find({ shardHash: shard.hash })
     .populate('contact')
-    .exec((err, mirrors) => {
-      let available = [];
-      for (let i = 0; i < mirrors.length; i++) {
-        let m = mirrors[i];
+    .sort({ timeoutRate: -1 })
+    .exec((err, results) => {
+      if (err) {
+        return callback(err);
+      }
+      const mirrors = results.filter((m) => {
         if (!m.contact) {
           log.warn('Mirror %s is missing contact in database', m._id);
+          return false;
         } else if (!m.isEstablished) {
-          available.push(m);
+          return true;
         }
-      }
-      callback(null, available.sort(Monitor.sortByTimeoutRate));
+      });
+      callback(null, mirrors);
     });
 };
 
 Monitor.prototype._fetchSources = function(shard, callback) {
-  const Contact = this.storage.models.Contact;
+  const farmers = shard.contracts.map((f) => f.farmer_id);
 
-  async.map(shard.contracts, (contract, next) => {
-    Contact.findOne({ _id: contract.farmer_id }, function(err, contact) {
-      let farmer = null;
-      if (err || !contact) {
-        log.error('Unable to load contact for farmer %s, reason: %s',
-                  contract.farmer_id, err ? err.message : null);
-      } else {
-        farmer = storj.Contact(contact.toObject());
+  this.storage.models.Contact
+    .find({ _id: { $in: farmers }})
+    .sort({ lastSeen: 1 })
+    .exec((err, results) => {
+      if (err) {
+        return callback(err);
       }
-      next(null, farmer);
+      const contacts = results.map((c) => storj.Contact(c.toObject()));
+      callback(null, contacts);
     });
-  }, (err, sources) => {
-    callback(err, sources.sort(Monitor.sortByLastSeen));
-  });
 };
 
 Monitor.prototype._saveShard = function(shard, destination) {

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -104,7 +104,20 @@ Monitor.prototype._fetchSources = function(shard, callback) {
         return callback(err);
       }
 
-      const contacts = results.map((c) => storj.Contact(c.toObject()));
+      let contacts = [];
+      for (let i = 0; i < results.length; i++) {
+        let c = results[i];
+        let contact = null;
+        try {
+          contact = storj.Contact(c.toObject());
+        } catch(e) {
+          log.warn('Unable to fetch source, invalid contact: %j', c.toObject());
+        }
+        if (contact) {
+          contacts.push(contact);
+        }
+      }
+
       callback(null, contacts);
     });
 };

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -115,7 +115,11 @@ Monitor.prototype._fetchSources = function(shard, callback) {
 };
 
 Monitor.prototype._saveShard = function(shard, destination) {
-  shard.addContract(destination.contact, destination.contract);
+
+  const contract = storj.Contract(destination.contract);
+  const contact = storj.Contact(destination.contact);
+  shard.addContract(contact, contract);
+
   this.contracts.save(shard, (err) => {
     if (err) {
       log.error('Unable to replicate shard %s, reason: %s',
@@ -201,7 +205,8 @@ Monitor.prototype._replicateFarmer = function(contact) {
       log.error('Unable to replicate farmer %s, reason: %s',
                 contact.nodeID, err.message);
     })
-    .on('data', (shard) => {
+    .on('data', (data) => {
+      const shard = storj.StorageItem(data.toObject());
       log.info('Replicating shard %s for farmer', shard.hash, contact.nodeID);
       this._replicateShard(shard);
     })

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -66,6 +66,150 @@ Monitor.prototype.start = function(callback) {
   process.on('uncaughtException', this._handleUncaughtException.bind(this));
 };
 
+Monitor.sortByTimeoutRate = function(a, b) {
+  const aTime = a.contact.timeoutRate || 1;
+  const bTime = b.contact.timeoutRate || 1;
+  return (aTime === bTime) ? 0 : (aTime < bTime) ? 1 : -1;
+};
+
+Monitor.sortByLastSeen = function(a, b) {
+  const aTime = a.contact.lastSeen || 0;
+  const bTime = b.contact.lastSeen || 0;
+  return (aTime === bTime) ? 0 : (aTime > bTime) ? 1 : -1;
+};
+
+Monitor.prototype._fetchDestinations = function(shard, callback) {
+  this.storage.models.Mirror.find({ shardHash: shard.hash })
+    .populate('contact')
+    .exec((err, mirrors) => {
+      let available = [];
+      for (let i = 0; i < mirrors.length; i++) {
+        let m = mirrors[i];
+        if (!m.contact) {
+          log.warn('Mirror %s is missing contact in database', m._id);
+        } else if (!m.isEstablished) {
+          available.push(m);
+        }
+      }
+      callback(null, available.sort(Monitor.sortByTimeoutRate));
+    });
+};
+
+Monitor.prototype._fetchSources = function(shard, callback) {
+  const Contact = this.storage.models.Contact;
+
+  async.map(shard.contracts, (contract, next) => {
+    Contact.findOne({ _id: contract.farmer_id }, function(err, contact) {
+      let farmer = null;
+      if (err || !contact) {
+        log.error('Unable to load contact for farmer %s, reason: %s',
+                  contract.farmer_id, err ? err.message : null);
+      } else {
+        farmer = storj.Contact(contact.toObject());
+      }
+      next(null, farmer);
+    });
+  }, (err, sources) => {
+    callback(err, sources.sort(Monitor.sortByLastSeen));
+  });
+};
+
+Monitor.prototype._saveShard = function(shard, destination) {
+  shard.addContract(destination.contact, destination.contract);
+  this.contracts.save(shard, (err) => {
+    if (err) {
+      log.error('Unable to replicate shard %s, reason: %s',
+                shard.hash, 'Unable save contract to shard');
+      return;
+    }
+
+    log.info('Successfully replicated shard %s', shard.hash);
+    destination.isEstablished = true;
+    destination.save((err) => {
+      if (err) {
+        log.error('Unable to update mirror as established, reason: %s',
+                  err.message);
+      }
+    });
+  });
+};
+
+Monitor.prototype._transferShard = function(shard, state) {
+  const source = state.sources[0];
+  const destination = state.destinations[0];
+
+  if (!source || !destination) {
+    return log.error('Unable to replicate shard %s, reason: %s',
+                     shard.hash, 'Sources and/or destinations exhausted');
+  }
+
+  const contract = destination.contract;
+
+  this.network.getRetrievalPointer(source, contract, (err, pointer) => {
+    if (err || !pointer) {
+      log.warn('Failed to get retrieval pointer from farmer %s, reason: %s',
+               source, err ? err.message : null);
+
+      state.sources.shift();
+      this._transferShard(shard, state);
+      return;
+    }
+
+    const farmer = storj.Contact(destination.contact);
+
+    this.network.getMirrorNodes([pointer], [farmer], (err) => {
+      if (err) {
+        log.warn('Unable to mirror to farmer %s, reason: %s',
+                 destination, err.message);
+        state.destinations.shift();
+        this._transferShard(shard, state);
+        return;
+      }
+
+      this._saveShard(shard, destination);
+    });
+  });
+};
+
+Monitor.prototype._replicateShard = function(shard) {
+  async.parallel({
+    destinations: (next) => {
+      this._fetchDestinations(shard, next);
+    },
+    sources: (next) => {
+      this._fetchSources(shard, next);
+    }
+  }, (err, state) => {
+    if (err) {
+      return log.error('Unable to replicate shard %s, reason: %s',
+                       shard.hash, err.message);
+    }
+    this._transferShard(shard, state);
+  });
+};
+
+Monitor.prototype._replicateFarmer = function(contact) {
+  log.info('Starting to replicate farmer %s', contact.nodeID);
+
+  const query = {
+    'contracts.nodeID': contact.nodeID
+  };
+  const cursor = this.storage.models.Shard.find(query);
+
+  cursor
+    .on('error', (err) => {
+      log.error('Unable to replicate farmer %s, reason: %s',
+                contact.nodeID, err.message);
+    })
+    .on('data', (shard) => {
+      log.info('Replicating shard %s for farmer', shard.hash, contact.nodeID);
+      this._replicateShard(shard);
+    })
+    .on('close', () => {
+      log.info('Ending replication of farmer %s', contact.nodeID);
+    });
+};
+
 Monitor.prototype.run = function() {
   if (this._running) {
     return this.wait();
@@ -136,6 +280,7 @@ Monitor.prototype.run = function() {
           if (contactData.timeoutRate >= timeoutRateThreshold) {
             log.warn('Shards need replication, farmer: %s, timeoutRate: %s',
                      contact.nodeID, contactData.timeoutRate);
+            //this._replicateFarmer(contact);
           }
 
         } else {

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -155,7 +155,16 @@ Monitor.prototype._transferShard = function(shard, state) {
                      shard.hash, 'Sources and/or destinations exhausted');
   }
 
-  const contract = destination.contract;
+  let contract = null;
+  try {
+    contract = storj.Contract(destination.contract);
+  } catch(e) {
+    log.warn('Unable to transfer shard, invalid contract: %j',
+             destination.contract);
+    state.destinations.shift();
+    this._transferShard(shard, state);
+    return;
+  }
 
   this.network.getRetrievalPointer(source, contract, (err, pointer) => {
     if (err || !pointer) {

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -87,6 +87,7 @@ Monitor.prototype._fetchDestinations = function(shard, callback) {
         } else if (!m.isEstablished) {
           return true;
         }
+        return false;
       });
       mirrors.sort(Monitor.sortByTimeoutRate);
       callback(null, mirrors);

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -70,7 +70,6 @@ Monitor.prototype._fetchDestinations = function(shard, callback) {
   this.storage.models.Mirror
     .find({ shardHash: shard.hash })
     .populate('contact')
-    .sort({ timeoutRate: -1 })
     .exec((err, results) => {
       if (err) {
         return callback(err);
@@ -83,6 +82,7 @@ Monitor.prototype._fetchDestinations = function(shard, callback) {
           return true;
         }
       });
+      // TODO sort by contact.timeoutRate
       callback(null, mirrors);
     });
 };
@@ -95,7 +95,7 @@ Monitor.prototype._fetchSources = function(shard, callback) {
 
   this.storage.models.Contact
     .find({ _id: { $in: farmers }})
-    .sort({ lastSeen: 1 })
+    .sort({ lastSeen: -1 })
     .exec((err, results) => {
       if (err) {
         return callback(err);

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -280,7 +280,7 @@ Monitor.prototype.run = function() {
           if (contactData.timeoutRate >= timeoutRateThreshold) {
             log.warn('Shards need replication, farmer: %s, timeoutRate: %s',
                      contact.nodeID, contactData.timeoutRate);
-            //this._replicateFarmer(contact);
+            this._replicateFarmer(contact);
           }
 
         } else {

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -88,7 +88,10 @@ Monitor.prototype._fetchDestinations = function(shard, callback) {
 };
 
 Monitor.prototype._fetchSources = function(shard, callback) {
-  const farmers = shard.contracts.map((f) => f.farmer_id);
+  let farmers = [];
+  for (let key in shard.contracts) {
+    farmers.push(shard.contracts[key].farmer_id);
+  }
 
   this.storage.models.Contact
     .find({ _id: { $in: farmers }})

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -67,8 +67,8 @@ Monitor.prototype.start = function(callback) {
 };
 
 Monitor.sortByTimeoutRate = function(a, b) {
-  const a1 = a.contact.timeoutRate || 0;
-  const b1 = b.contact.timeoutRate || 0;
+  const a1 = a.contact.timeoutRate >= 0 ? a.contact.timeoutRate : Infinity;
+  const b1 = b.contact.timeoutRate >= 0 ? b.contact.timeoutRate : Infinity;
   return (a1 === b1) ? 0 : (a1 > b1) ? 1 : -1;
 };
 

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -94,10 +94,7 @@ Monitor.prototype._fetchDestinations = function(shard, callback) {
 };
 
 Monitor.prototype._fetchSources = function(shard, callback) {
-  let farmers = [];
-  for (let key in shard.contracts) {
-    farmers.push(shard.contracts[key].farmer_id);
-  }
+  let farmers = Object.keys(shard.contracts);
 
   this.storage.models.Contact
     .find({ _id: { $in: farmers }})
@@ -106,6 +103,7 @@ Monitor.prototype._fetchSources = function(shard, callback) {
       if (err) {
         return callback(err);
       }
+
       const contacts = results.map((c) => storj.Contact(c.toObject()));
       callback(null, contacts);
     });

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "storj-service-error-types": "^1.1.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.2.1",
-    "storj-service-storage-models": "^8.6.0",
+    "storj-service-storage-models": "^8.8.1",
     "through": "^2.3.8"
   }
 }

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -187,6 +187,8 @@ describe('Monitor', function() {
           address: '127.0.0.1',
           port: 10001
         })
+      }, {
+        toObject: sandbox.stub().returns({}) // invalid contact
       }];
       const exec = sandbox.stub().callsArgWith(0, null, results);
       const sort = sandbox.stub().returns({exec: exec});

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -62,13 +62,52 @@ describe('Monitor', function() {
 
   });
 
+  describe('@sortByTimeoutRate', function() {
+    it('will sort with the best timeout rate (0) at top', function() {
+      const mirrors = [{
+        contact: { timeoutRate: 0.99 }
+      }, {
+        contact: { timeoutRate: 0.03 }
+      }, {
+        contact: { timeoutRate: 0.98 }
+      }, {
+        contact: { timeoutRate: 1 }
+      }, {
+        contact: { timeoutRate: 0 }
+      }];
+
+      mirrors.sort(Monitor.sortByTimeoutRate);
+
+      expect(mirrors).to.eql([{
+        contact: { timeoutRate: 0 }
+      }, {
+        contact: { timeoutRate: 0.03 }
+      }, {
+        contact: { timeoutRate: 0.98 }
+      }, {
+        contact: { timeoutRate: 0.99 }
+      }, {
+        contact: { timeoutRate: 1 }
+      }]);
+    });
+  });
+
   describe('#_fetchDestinations', function() {
     it('it will filter and sort mirrors', function(done) {
+      sandbox.spy(Monitor, 'sortByTimeoutRate');
       const monitor = new Monitor(config);
       const results = [
         {},
         {
-          contact: {},
+          contact: {
+            timeoutRate: 0.001
+          },
+          isEstablished: false
+        },
+        {
+          contact: {
+            timeoutRate: 0.01
+          },
           isEstablished: false
         },
         {
@@ -97,8 +136,10 @@ describe('Monitor', function() {
         expect(find.callCount).to.equal(1);
         expect(find.args[0][0].shardHash).to.equal(shard.hash);
         expect(exec.callCount).to.equal(1);
-        expect(mirrors.length).to.equal(1);
+        expect(mirrors.length).to.equal(2);
         expect(mirrors[0].isEstablished).to.equal(false);
+        expect(mirrors[0].contact.timeoutRate).to.equal(0.001);
+        expect(Monitor.sortByTimeoutRate.callCount).to.equal(1);
         done();
       });
     });

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -154,11 +154,14 @@ describe('Monitor', function() {
         }
       };
       const shard = {
-        contracts: [{
-          farmer_id: 'farmer1'
-        },{
-          farmer_id: 'farmer2'
-        }]
+        contracts: {
+          'farmer1': {
+            farmer_id: 'farmer1'
+          },
+          'farmer2': {
+            farmer_id: 'farmer2'
+          }
+        }
       };
 
       monitor._fetchSources(shard, (err, contacts) => {
@@ -192,11 +195,14 @@ describe('Monitor', function() {
         }
       };
       const shard = {
-        contracts: [{
-          farmer_id: 'farmer1'
-        },{
-          farmer_id: 'farmer2'
-        }]
+        contracts: {
+          'farmer1': {
+            farmer_id: 'farmer1'
+          },
+          'farmer2': {
+            farmer_id: 'farmer2'
+          }
+        }
       };
 
       monitor._fetchSources(shard, (err) => {

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -77,8 +77,7 @@ describe('Monitor', function() {
         }
       ];
       const exec = sandbox.stub().callsArgWith(0, null, results);
-      const sort = sandbox.stub().returns({exec: exec});
-      const populate = sandbox.stub().returns({sort: sort});
+      const populate = sandbox.stub().returns({exec: exec});
       const find = sandbox.stub().returns({populate: populate});
       monitor.storage = {
         models: {
@@ -94,8 +93,6 @@ describe('Monitor', function() {
         if (err) {
           return done(err);
         }
-        expect(sort.callCount).to.equal(1);
-        expect(sort.args[0][0].timeoutRate).to.equal(-1);
         expect(populate.callCount).to.equal(1);
         expect(find.callCount).to.equal(1);
         expect(find.args[0][0].shardHash).to.equal(shard.hash);
@@ -108,8 +105,7 @@ describe('Monitor', function() {
     it('it will give error on query failure', function(done) {
       const monitor = new Monitor(config);
       const exec = sandbox.stub().callsArgWith(0, new Error('test'));
-      const sort = sandbox.stub().returns({exec: exec});
-      const populate = sandbox.stub().returns({sort: sort});
+      const populate = sandbox.stub().returns({exec: exec});
       const find = sandbox.stub().returns({populate: populate});
       monitor.storage = {
         models: {
@@ -171,7 +167,7 @@ describe('Monitor', function() {
         expect(find.callCount).to.equal(1);
         expect(find.args[0][0]._id.$in).to.eql(['farmer1', 'farmer2']);
         expect(sort.callCount).to.equal(1);
-        expect(sort.args[0][0].lastSeen).to.equal(1);
+        expect(sort.args[0][0].lastSeen).to.equal(-1);
         expect(exec.callCount).to.equal(1);
         expect(contacts.length).to.equal(2);
         expect(contacts[0]).to.be.instanceOf(storj.Contact);

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -62,6 +62,79 @@ describe('Monitor', function() {
 
   });
 
+  describe('#_saveShard', function() {
+    it('it will add contract, save shard and update mirror', function() {
+      sandbox.stub(log, 'error');
+      const monitor = new Monitor(config);
+      monitor.contracts = {
+        save: sandbox.stub().callsArgWith(1, null)
+      };
+      const shard = {
+        addContract: sandbox.stub()
+      };
+      const destination = {
+        save: sandbox.stub().callsArgWith(0, null),
+        contact: {
+          address: '127.0.0.1',
+          port: 10000
+        },
+        contract: {}
+      };
+      monitor._saveShard(shard, destination);
+      expect(shard.addContract.callCount).to.equal(1);
+      expect(shard.addContract.args[0][0]).to.be.instanceOf(storj.Contact);
+      expect(shard.addContract.args[0][1]).to.be.instanceOf(storj.Contract);
+      expect(monitor.contracts.save.callCount).to.equal(1);
+      expect(destination.save.callCount).to.equal(1);
+      expect(log.error.callCount).to.equal(0);
+      expect(destination.isEstablished).to.equal(true);
+    });
+    it('it will log error saving contract', function() {
+      sandbox.stub(log, 'error');
+      const monitor = new Monitor(config);
+      monitor.contracts = {
+        save: sandbox.stub().callsArgWith(1, new Error('test'))
+      };
+      const shard = {
+        addContract: sandbox.stub()
+      };
+      const destination = {
+        save: sandbox.stub().callsArgWith(0, null),
+        contact: {
+          address: '127.0.0.1',
+          port: 10000
+        },
+        contract: {}
+      };
+      monitor._saveShard(shard, destination);
+      expect(monitor.contracts.save.callCount).to.equal(1);
+      expect(log.error.callCount).to.equal(1);
+      expect(destination.save.callCount).to.equal(0);
+    });
+    it('it will log error saving mirror', function() {
+      sandbox.stub(log, 'error');
+      const monitor = new Monitor(config);
+      monitor.contracts = {
+        save: sandbox.stub().callsArgWith(1, null)
+      };
+      const shard = {
+        addContract: sandbox.stub()
+      };
+      const destination = {
+        save: sandbox.stub().callsArgWith(0, new Error('test')),
+        contact: {
+          address: '127.0.0.1',
+          port: 10000
+        },
+        contract: {}
+      };
+      monitor._saveShard(shard, destination);
+      expect(monitor.contracts.save.callCount).to.equal(1);
+      expect(destination.save.callCount).to.equal(1);
+      expect(log.error.callCount).to.equal(1);
+    });
+  });
+
   describe('#_transferShard', function() {
     const sandbox = sinon.sandbox.create();
     afterEach(() => sandbox.restore());

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -69,6 +69,10 @@ describe('Monitor', function() {
       }, {
         contact: { timeoutRate: 0.03 }
       }, {
+        contact: { }
+      }, {
+        contact: { timeoutRate: 0.98 }
+      }, {
         contact: { timeoutRate: 0.98 }
       }, {
         contact: { timeoutRate: 1 }
@@ -85,9 +89,13 @@ describe('Monitor', function() {
       }, {
         contact: { timeoutRate: 0.98 }
       }, {
+        contact: { timeoutRate: 0.98 }
+      }, {
         contact: { timeoutRate: 0.99 }
       }, {
         contact: { timeoutRate: 1 }
+      }, {
+        contact: { }
       }]);
     });
   });

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -200,12 +200,8 @@ describe('Monitor', function() {
       };
       const shard = {
         contracts: {
-          'farmer1': {
-            farmer_id: 'farmer1'
-          },
-          'farmer2': {
-            farmer_id: 'farmer2'
-          }
+          'farmer1': {},
+          'farmer2': {}
         }
       };
 
@@ -241,12 +237,8 @@ describe('Monitor', function() {
       };
       const shard = {
         contracts: {
-          'farmer1': {
-            farmer_id: 'farmer1'
-          },
-          'farmer2': {
-            farmer_id: 'farmer2'
-          }
+          'farmer1': {},
+          'farmer2': {}
         }
       };
 

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -83,6 +83,8 @@ describe('Monitor', function() {
       mirrors.sort(Monitor.sortByTimeoutRate);
 
       expect(mirrors).to.eql([{
+        contact: { }
+      }, {
         contact: { timeoutRate: 0 }
       }, {
         contact: { timeoutRate: 0.03 }
@@ -94,8 +96,6 @@ describe('Monitor', function() {
         contact: { timeoutRate: 0.99 }
       }, {
         contact: { timeoutRate: 1 }
-      }, {
-        contact: { }
       }]);
     });
   });

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -256,7 +256,11 @@ describe('Monitor', function() {
           }
         }
       };
-      const data = {};
+      const data = {
+        toObject: sandbox.stub().returns({
+          hash: '03780c65a61ebe7334e9ff2a9267a9d725fc2d4b'
+        })
+      };
       const contact = {
         nodeID: '353ba728e2d74826c2fcbf5ada2fe1c402e3eda1'
       };
@@ -265,7 +269,11 @@ describe('Monitor', function() {
       cursor.on('data', () => {
         expect(log.info.callCount).to.equal(2);
         expect(monitor._replicateShard.callCount).to.equal(1);
-        expect(monitor._replicateShard.args[0][0]).to.equal(data);
+        expect(monitor._replicateShard.args[0][0])
+          .to.be.instanceOf(storj.StorageItem);
+        expect(monitor._replicateShard.args[0][0].hash)
+          .to.equal('03780c65a61ebe7334e9ff2a9267a9d725fc2d4b');
+        expect(data.toObject.callCount).to.equal(1);
         done();
       });
       cursor.emit('data', data);

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -197,6 +197,7 @@ describe('Monitor', function() {
         }
       };
       monitor.wait = sandbox.stub();
+      monitor._replicateFarmer = sinon.stub();
       monitor.run();
 
       expect(find.callCount).to.equal(1);
@@ -240,6 +241,9 @@ describe('Monitor', function() {
         .to.equal('7b8b30132e930c7827ee47efebfb197d6a3246d4');
       expect(log.warn.args[0][2])
         .to.equal(0.05);
+      expect(monitor._replicateFarmer.callCount).to.equal(1);
+      expect(monitor._replicateFarmer.args[0][0])
+        .to.be.instanceOf(storj.Contact);
 
       expect(monitor.network.ping.callCount).to.equal(3);
       expect(monitor.network.ping.args[0][0]).to.be.instanceOf(storj.Contact);

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -62,6 +62,42 @@ describe('Monitor', function() {
 
   });
 
+  describe('#_replicateShard', function() {
+    const sandbox = sinon.sandbox.create();
+    afterEach(() => sandbox.restore());
+
+    it('it will fetch sources and destinations', function() {
+      const monitor = new Monitor(config);
+      monitor._transferShard = sinon.stub();
+      const destinations = [];
+      const sources = [];
+      monitor._fetchDestinations = sinon.stub()
+        .callsArgWith(1, null, destinations);
+      monitor._fetchSources = sinon.stub().callsArgWith(1, null, sources);
+      const shard = {};
+      monitor._replicateShard(shard);
+      expect(monitor._transferShard.callCount).to.equal(1);
+      expect(monitor._transferShard.args[0][0]).to.equal(shard);
+      expect(monitor._transferShard.args[0][1]).to.eql({
+        sources: [],
+        destinations: []
+      });
+    });
+
+    it('it will handle error from queries', function() {
+      sandbox.stub(log, 'error');
+      const monitor = new Monitor(config);
+      monitor._transferShard = sinon.stub();
+      const destinations = [];
+      monitor._fetchDestinations = sinon.stub()
+        .callsArgWith(1, null, destinations);
+      monitor._fetchSources = sinon.stub().callsArgWith(1, new Error('test'));
+      const shard = {};
+      monitor._replicateShard(shard);
+      expect(log.error.callCount).to.equal(1);
+    });
+  });
+
   describe('#_replicateFarmer', function() {
     const sandbox = sinon.sandbox.create();
     afterEach(() => sandbox.restore());

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -444,7 +444,9 @@ describe('Monitor', function() {
       monitor.storage = {
         models: {
           Shard: {
-            find: sinon.stub().returns(cursor)
+            find: sandbox.stub().returns({
+              cursor: sandbox.stub().returns(cursor)
+            })
           }
         }
       };
@@ -469,7 +471,9 @@ describe('Monitor', function() {
       monitor.storage = {
         models: {
           Shard: {
-            find: sinon.stub().returns(cursor)
+            find: sandbox.stub().returns({
+              cursor: sandbox.stub().returns(cursor)
+            })
           }
         }
       };
@@ -503,7 +507,9 @@ describe('Monitor', function() {
       monitor.storage = {
         models: {
           Shard: {
-            find: sinon.stub().returns(cursor)
+            find: sandbox.stub().returns({
+              cursor: sandbox.stub().returns(cursor)
+            })
           }
         }
       };


### PR DESCRIPTION
This will create an additional mirror for all associated shards for a contact when the contact is unreachable for 1 hour in 24 hours.