### PR TITLE
Bucket deletion removes files

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -185,7 +185,8 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
     }], 
     function(err, results) {
       if (err) {
-        return console.log(err.message);
+        log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
+                err.message);
       }
 
       let bucketRemovalStorageEvents = results.map(function(result) {

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -181,7 +181,7 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
         user: {$literal: req.user._id},
         downloadBandwidth: {$literal: 0},
         storage: {$multiply: [-1, '$frameData.size']},
-        timestamp: new Date()
+        timestamp: {$add: [new Date(), 0]}
       }
     }], 
     function(err, storageEvents) {

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -215,10 +215,10 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
                 err.message);
             }
             StorageEvent.collection.insert(storageEvents, function(err) {
-            if (err) {
-              log.warn('Unable to save storage events, reason: %s',
-                err.message);
-            }
+              if (err) {
+                log.warn('Unable to save storage events, reason: %s',
+                  err.message);
+              }
           });
         });
         });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -9,6 +9,7 @@ const tokenauth = middleware.tokenauth;
 const publicBucket = middleware.publicBucket;
 const log = require('../../logger');
 const merge = require('merge');
+const mongoose = require('mongoose');
 const errors = require('storj-service-error-types');
 const Router = require('./index');
 const inherits = require('util').inherits;
@@ -152,12 +153,14 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
   const StorageEvent = this.storage.models.StorageEvent;
 
+  const bucketObjectId = new mongoose.Types.ObjectId(req.params.id);
+
   log.info('removing bucket %s for %s', req.params.id, req.user._id);
 
   BucketEntry.aggregate([
     {
       $match: {
-        bucket: req.params.id
+        bucket: bucketObjectId
       }
     },
     {

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -180,18 +180,15 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
         bucketEntry: '$_id',
         user: {$literal: req.user._id},
         downloadBandwidth: {$literal: 0},
-        storage: {$multiply: [-1, '$frameData.size']}
+        storage: {$multiply: [-1, '$frameData.size']},
+        timestamp: new Date()
       }
     }], 
-    function(err, results) {
+    function(err, storageEvents) {
       if (err) {
         log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
                 err.message);
       }
-
-      let bucketRemovalStorageEvents = results.map(function(result) {
-        return new StorageEvent(result);
-      });
 
       Bucket.findOne({
       _id: req.params.id,
@@ -214,9 +211,7 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
             log.error('Unable to remove bucket entries, reason: %s',
                       err.message);
           }
-          async.eachSeries(bucketRemovalStorageEvents, function(storageEvent, done) {
-            storageEvent.save(done);
-          }, function(err) {
+          StorageEvent.collection.insert(storageEvents, function(err) {
                if (err) {
                  log.warn('Unable to save storage events, reason: %s',
                           err.message);

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -162,25 +162,25 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
     },
     {
       $lookup: {
-        from: "frames",
-        localField: "frame",
-        foreignField: "_id",
-        as: "frameData"
+        from: 'frames',
+        localField: 'frame',
+        foreignField: '_id',
+        as: 'frameData'
     }
     },
     {
       $unwind: {
-        path: "$frameData"
+        path: '$frameData'
       }
     },
     {
       $project: {
         _id: 0,
-        bucket: "$bucket",
-        bucketEntry: "$_id",
+        bucket: '$bucket',
+        bucketEntry: '$_id',
         user: {$literal: req.user._id},
         downloadBandwidth: {$literal: 0},
-        storage: {$multiply: [-1, "$frameData.size"]}
+        storage: {$multiply: [-1, '$frameData.size']}
       }
     }], 
     function(err, results) {

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -174,6 +174,38 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
           log.error('Unable to remove bucket entries, reason: %s',
                     err.message);
         }
+
+        BucketEntry.aggregate([
+          {
+            $match: {
+              bucket: req.params.id
+            }
+          },
+          {
+            $lookup: {
+              from: "frames",
+              localField: "frame",
+              foreignField: "_id",
+              as: "frameData"
+            }
+          },
+          {
+            $unwind: {
+              path: "$frameData"
+            }
+          },
+          {
+            $project: {
+              _id: 0,
+              bucket: "$bucket",
+              bucketEntry: "$_id",
+              user: "$frameData.user",
+              downloadBandwidth: {$litteral: 0},
+              storage: {$multiply: [-1, "$frameData.size"]}
+            }
+          }]).cursor({batchSize: 100, async: true})
+             .exec()
+        });
       });
       res.status(204).end();
     });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -214,11 +214,13 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
             log.error('Unable to remove bucket entries, reason: %s',
                       err.message);
           }
-          StorageEvent.collection.insert(bucketRemovalStorageEvents, function(err) {
-            if (err) {
-              log.warn('Unable to save storage events, reason: %s',
-                        err.message);
-            }
+          async.eachSeries(bucketRemovalStorageEvents, function(storageEvent, done) {
+            storageEvent.save(done);
+          }, function(err) {
+               if (err) {
+                 log.warn('Unable to save storage events, reason: %s',
+                          err.message);
+               }
           });
         });
       });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -216,7 +216,7 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
           }
           StorageEvent.collection.insert(bucketRemovalStorageEvents, function(err) {
             if (err) {
-              log.error('Unable to save storage events, reason: %s',
+              log.warn('Unable to save storage events, reason: %s',
                         err.message);
             }
           });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -192,7 +192,6 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
         log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
                 err.message);
       }
-      log.info('Aggregation storage events: %s', storageEvents);
 
       Bucket.findOne({
       _id: req.params.id,
@@ -215,12 +214,11 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
             log.error('Unable to remove bucket entries, reason: %s',
                       err.message);
           }
-          StorageEvent.collection.insert(storageEvents, function(err, se) {
+          StorageEvent.collection.insert(storageEvents, function(err) {
                if (err) {
                  log.warn('Unable to save storage events, reason: %s',
                           err.message);
                }
-               log.info('Storage event bulk insert data: %s', se);
           });
         });
       });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -153,58 +153,71 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
 
   log.info('removing bucket %s for %s', req.params.id, req.user._id);
 
-  Bucket.findOne({
-    _id: req.params.id,
-    user: req.user._id
-  }, function(err, bucket) {
-    if (err) {
-      return next(new errors.InternalError(err.message));
+  BucketEntry.aggregate([
+    {
+      $match: {
+        bucket: req.params.id
+      }
+    },
+    {
+      $lookup: {
+        from: "frames",
+        localField: "frame",
+        foreignField: "_id",
+        as: "frameData"
     }
+    },
+    {
+      $unwind: {
+        path: "$frameData"
+      }
+    },
+    {
+      $project: {
+        _id: 0,
+        bucket: "$bucket",
+        bucketEntry: "$_id",
+        user: {$literal: req.user._id},
+        downloadBandwidth: {$literal: 0},
+        storage: {$multiply: [-1, "$frameData.size"]}
+      }
+    }], 
+    function(err, results) {
+      if (err) {
+        return console.log(err.message);
+      }
 
-    if (!bucket) {
-      return next(new errors.NotFoundError('Bucket not found'));
-    }
+      let bucketRemovalStorageEvents = results.map(function(result) {
+        return new StorageEvent(result);
+      });
 
-    bucket.remove(function(err) {
+      Bucket.findOne({
+      _id: req.params.id,
+      user: req.user._id
+      }, function(err, bucket) {
       if (err) {
         return next(new errors.InternalError(err.message));
       }
-      BucketEntry.remove({ bucket: req.params.id }, (err) => {
-        if (err) {
-          log.error('Unable to remove bucket entries, reason: %s',
-                    err.message);
-        }
 
-        BucketEntry.aggregate([
-          {
-            $match: {
-              bucket: req.params.id
+      if (!bucket) {
+        return next(new errors.NotFoundError('Bucket not found'));
+      }
+
+      bucket.remove(function(err) {
+        if (err) {
+          return next(new errors.InternalError(err.message));
+        }
+        BucketEntry.remove({ bucket: req.params.id }, (err) => {
+          if (err) {
+            log.error('Unable to remove bucket entries, reason: %s',
+                      err.message);
+          }
+          StorageEvent.collection.insert(bucketRemovalStorageEvents, function(err) {
+            if (err) {
+              log.error('Unable to save storage events, reason: %s',
+                        err.message);
             }
-          },
-          {
-            $lookup: {
-              from: "frames",
-              localField: "frame",
-              foreignField: "_id",
-              as: "frameData"
-            }
-          },
-          {
-            $unwind: {
-              path: "$frameData"
-            }
-          },
-          {
-            $project: {
-              _id: 0,
-              bucket: "$bucket",
-              bucketEntry: "$_id",
-              user: "$frameData.user",
-              downloadBandwidth: {$litteral: 0},
-              storage: {$multiply: [-1, "$frameData.size"]}
-            }
-          }]).cursor({batchSize: 100, async: true})
-             .exec()
+          });
         });
       });
       res.status(204).end();

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -150,6 +150,7 @@ BucketsRouter.prototype.createBucket = function(req, res, next) {
 BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
   const Bucket = this.storage.models.Bucket;
   const BucketEntry = this.storage.models.BucketEntry;
+  const StorageEvent = this.storage.models.StorageEvent;
 
   log.info('removing bucket %s for %s', req.params.id, req.user._id);
 

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -158,73 +158,73 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
   log.info('removing bucket %s for %s', req.params.id, req.user._id);
 
   BucketEntry.aggregate([
-    {
-      $match: {
-        bucket: bucketObjectId
-      }
-    },
-    {
-      $lookup: {
-        from: 'frames',
-        localField: 'frame',
-        foreignField: '_id',
-        as: 'frameData'
-    }
-    },
-    {
-      $unwind: {
-        path: '$frameData'
-      }
-    },
-    {
-      $project: {
-        _id: 0,
-        bucket: '$bucket',
-        bucketEntry: '$_id',
-        user: {$literal: req.user._id},
-        downloadBandwidth: {$literal: 0},
-        storage: {$multiply: [-1, '$frameData.size']},
-        timestamp: {$add: [new Date(), 0]}
-      }
-    }], 
+      {
+        $match: {
+          bucket: bucketObjectId
+        }
+      },
+      {
+        $lookup: {
+          from: 'frames',
+          localField: 'frame',
+          foreignField: '_id',
+          as: 'frameData'
+        }
+      },
+      {
+        $unwind: {
+          path: '$frameData'
+        }
+      },
+      {
+        $project: {
+          _id: 0,
+          bucket: '$bucket',
+          bucketEntry: '$_id',
+          user: {$literal: req.user._id},
+          downloadBandwidth: {$literal: 0},
+          storage: {$multiply: [-1, '$frameData.size']},
+          timestamp: {$add: [new Date(), 0]}
+        }
+      }],
     function(err, storageEvents) {
       if (err) {
         log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
-                err.message);
+          err.message);
       }
 
       Bucket.findOne({
-      _id: req.params.id,
-      user: req.user._id
+        _id: req.params.id,
+        user: req.user._id
       }, function(err, bucket) {
-      if (err) {
-        return next(new errors.InternalError(err.message));
-      }
-
-      if (!bucket) {
-        return next(new errors.NotFoundError('Bucket not found'));
-      }
-
-      bucket.remove(function(err) {
         if (err) {
           return next(new errors.InternalError(err.message));
         }
-        BucketEntry.remove({ bucket: req.params.id }, (err) => {
+
+        if (!bucket) {
+          return next(new errors.NotFoundError('Bucket not found'));
+        }
+
+        bucket.remove(function(err) {
           if (err) {
-            log.error('Unable to remove bucket entries, reason: %s',
-                      err.message);
+            return next(new errors.InternalError(err.message));
           }
-          StorageEvent.collection.insert(storageEvents, function(err) {
-               if (err) {
-                 log.warn('Unable to save storage events, reason: %s',
-                          err.message);
-               }
+          BucketEntry.remove({ bucket: req.params.id }, (err) => {
+            if (err) {
+              log.error('Unable to remove bucket entries, reason: %s',
+                err.message);
+            }
+            StorageEvent.collection.insert(storageEvents, function(err) {
+            if (err) {
+              log.warn('Unable to save storage events, reason: %s',
+                err.message);
+            }
           });
         });
+        });
+        res.status(204).end();
       });
-      res.status(204).end();
     });
-  });
 };
 
 /**

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -189,6 +189,7 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
         log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
                 err.message);
       }
+      log.info('Aggregation storage events: %s', storageEvents);
 
       Bucket.findOne({
       _id: req.params.id,
@@ -211,11 +212,12 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
             log.error('Unable to remove bucket entries, reason: %s',
                       err.message);
           }
-          StorageEvent.collection.insert(storageEvents, function(err) {
+          StorageEvent.collection.insert(storageEvents, function(err, se) {
                if (err) {
                  log.warn('Unable to save storage events, reason: %s',
                           err.message);
                }
+               log.info('Storage event bulk insert data: %s', se);
           });
         });
       });

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -548,16 +548,16 @@ describe('BucketsRouter', function() {
          bucketsRouter.storage.models.BucketEntry,
          'remove'
       ).callsArgWith(1, null);
-      var _storageEventInsert = sinon.stub(
-        bucketsRouter.storage.models.StorageEvent.collection,
-        'insert'
-      ).callsArgWith(1, new Error('Storage events failed to save'));
+      var _storageEventSave = sinon.stub(
+        bucketsRouter.storage.models.StorageEvent.prototype,
+        'save'
+      ).callsArgWith(0, new Error('Storage events failed to save'));
       response.on('end', function() {
         _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         _bucketRemove.restore();
         _bucketEntryRemove.restore();
-        _storageEventInsert.restore();
+        _storageEventSave.restore();
         expect(log.warn.callCount).to.equal(1);
         done();
       });
@@ -590,16 +590,16 @@ describe('BucketsRouter', function() {
          bucketsRouter.storage.models.BucketEntry,
          'remove'
       ).callsArgWith(1, null);
-      var _storageEventInsert = sinon.stub(
-        bucketsRouter.storage.models.StorageEvent.collection,
-        'insert'
-      ).callsArgWith(1, null);
+      var _storageEventSave = sinon.stub(
+        bucketsRouter.storage.models.StorageEvent.prototype,
+        'save'
+      ).callsArgWith(0, null);
       response.on('end', function() {
         _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         _bucketRemove.restore();
         _bucketEntryRemove.restore();
-        _storageEventInsert.restore();
+        _storageEventSave.restore();
         expect(response.statusCode).to.equal(204);
         done();
       });

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -548,16 +548,16 @@ describe('BucketsRouter', function() {
          bucketsRouter.storage.models.BucketEntry,
          'remove'
       ).callsArgWith(1, null);
-      var _storageEventSave = sinon.stub(
-        bucketsRouter.storage.models.StorageEvent.prototype,
-        'save'
-      ).callsArgWith(0, new Error('Storage events failed to save'));
+      var _storageEventInsert = sinon.stub(
+        bucketsRouter.storage.models.StorageEvent.collection,
+        'insert'
+      ).callsArgWith(1, new Error('Storage events failed to save'));
       response.on('end', function() {
         _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         _bucketRemove.restore();
         _bucketEntryRemove.restore();
-        _storageEventSave.restore();
+        _storageEventInsert.restore();
         expect(log.warn.callCount).to.equal(1);
         done();
       });
@@ -590,16 +590,16 @@ describe('BucketsRouter', function() {
          bucketsRouter.storage.models.BucketEntry,
          'remove'
       ).callsArgWith(1, null);
-      var _storageEventSave = sinon.stub(
-        bucketsRouter.storage.models.StorageEvent.prototype,
-        'save'
-      ).callsArgWith(0, null);
+      var _storageEventInsert = sinon.stub(
+        bucketsRouter.storage.models.StorageEvent.collection,
+        'insert'
+      ).callsArgWith(1, null);
       response.on('end', function() {
         _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         _bucketRemove.restore();
         _bucketEntryRemove.restore();
-        _storageEventSave.restore();
+        _storageEventInsert.restore();
         expect(response.statusCode).to.equal(204);
         done();
       });

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -351,11 +351,16 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
+      var _bucketEntryAggregate = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        "aggregate"
+      ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
       ).callsArgWith(1, new Error('Failed to lookup bucket'));
       bucketsRouter.destroyBucketById(request, response, function(err) {
+        _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         expect(err.message).to.equal('Failed to lookup bucket');
         done();
@@ -372,11 +377,16 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
+      var _bucketEntryAggregate = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        "aggregate"
+      ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
       ).callsArgWith(1, null, null);
       bucketsRouter.destroyBucketById(request, response, function(err) {
+        _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         expect(err.message).to.equal('Bucket not found');
         done();
@@ -394,6 +404,10 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
+      sandbox.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'aggregate'
+      ).callsArgWith(1, null, [{}]);
       sandbox.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
@@ -421,6 +435,10 @@ describe('BucketsRouter', function() {
       var bucket = new bucketsRouter.storage.models.Bucket({
         user: someUser._id
       });
+      var _bucketEntryAggregate = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        "aggregate"
+      ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
@@ -430,6 +448,7 @@ describe('BucketsRouter', function() {
         new Error('Failed to remove bucket')
       );
       bucketsRouter.destroyBucketById(request, response, function(err) {
+        _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         _bucketRemove.restore();
         expect(err.message).to.equal('Failed to remove bucket');
@@ -450,12 +469,17 @@ describe('BucketsRouter', function() {
       var bucket = new bucketsRouter.storage.models.Bucket({
         user: someUser._id
       });
+      var _bucketEntryAggregate = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        "aggregate"
+      ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
       ).callsArgWith(1, null, bucket);
       var _bucketRemove = sinon.stub(bucket, 'remove').callsArg(0);
       response.on('end', function() {
+        _bucketEntryAggregate.restore();
         _bucketFindOne.restore();
         _bucketRemove.restore();
         expect(response.statusCode).to.equal(204);

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -488,7 +488,7 @@ describe('BucketsRouter', function() {
       bucketsRouter.destroyBucketById(request, response);
     });
 
-    it('should internal error if aggregation fails', function(done) {
+    it('should log warning if aggregation fails', function(done) {
       sandbox.stub(log, 'warn');
       var request = httpMocks.createRequest({
         method: 'DELETE',

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -564,6 +564,48 @@ describe('BucketsRouter', function() {
       bucketsRouter.destroyBucketById(request, response);
     });
 
+    it('should respond with 204 when storage events get saved', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'DELETE',
+        url: '/buckets/:bucket_id'
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      var _bucketEntryAggregate = sinon.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'aggregate'
+      ).callsArgWith(1, null, [{}, {}]);
+      var bucket = new bucketsRouter.storage.models.Bucket({
+        user: someUser._id
+      });
+      var _bucketFindOne = sinon.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(1, null, bucket);
+      var _bucketRemove = sinon.stub(bucket, 'remove').callsArg(0, null);
+      var _bucketEntryRemove = sinon.stub(
+         bucketsRouter.storage.models.BucketEntry,
+         'remove'
+      ).callsArgWith(1, null);
+      var _storageEventInsert = sinon.stub(
+        bucketsRouter.storage.models.StorageEvent.collection,
+        'insert'
+      ).callsArgWith(1, null);
+      response.on('end', function() {
+        _bucketEntryAggregate.restore();
+        _bucketFindOne.restore();
+        _bucketRemove.restore();
+        _bucketEntryRemove.restore();
+        _storageEventInsert.restore();
+        expect(response.statusCode).to.equal(204);
+        done();
+      });
+      bucketsRouter.destroyBucketById(request, response);
+    });
+
   });
 
   describe('#updateBucketById', function() {

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -354,7 +354,7 @@ describe('BucketsRouter', function() {
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
         'aggregate'
-      ).callsArgWith(1, null, [{}])
+      ).callsArgWith(1, null, [{}]);
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
@@ -380,7 +380,7 @@ describe('BucketsRouter', function() {
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
         'aggregate'
-      ).callsArgWith(1, null, [{}])
+      ).callsArgWith(1, null, [{}]);
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
@@ -438,7 +438,7 @@ describe('BucketsRouter', function() {
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
         'aggregate'
-      ).callsArgWith(1, null, [{}])
+      ).callsArgWith(1, null, [{}]);
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'
@@ -472,7 +472,7 @@ describe('BucketsRouter', function() {
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
         'aggregate'
-      ).callsArgWith(1, null, [{}])
+      ).callsArgWith(1, null, [{}]);
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
         'findOne'

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -353,7 +353,7 @@ describe('BucketsRouter', function() {
       });
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
-        "aggregate"
+        'aggregate'
       ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
@@ -379,7 +379,7 @@ describe('BucketsRouter', function() {
       });
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
-        "aggregate"
+        'aggregate'
       ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
@@ -437,7 +437,7 @@ describe('BucketsRouter', function() {
       });
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
-        "aggregate"
+        'aggregate'
       ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,
@@ -471,7 +471,7 @@ describe('BucketsRouter', function() {
       });
       var _bucketEntryAggregate = sinon.stub(
         bucketsRouter.storage.models.BucketEntry,
-        "aggregate"
+        'aggregate'
       ).callsArgWith(1, null, [{}])
       var _bucketFindOne = sinon.stub(
         bucketsRouter.storage.models.Bucket,


### PR DESCRIPTION
When we delete a bucket we need to capture the associated storage event data. Each bucket removed will generate a storage event for each file contained within. 