### PR TITLE
[WIP] Working example of rate limiter implementation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -69,6 +69,15 @@ const DEFAULTS = {
         monthlyBytes: 180000000000
       }
     }
+  },
+  redis: {
+    host: '',
+    port: '',
+    path: '',
+    url: '',
+    password: '',
+    db: '',
+    tls: {}
   }
 };
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -59,6 +59,13 @@ Engine.prototype.start = function(callback) {
     new MongoDBStorageAdapter(this.storage),
     { disableReaper: true }
   );
+  this.client = require('redis').createClient(this._config.redis);
+  this.client.on('ready', (data) => {
+    log.info('connected to redis');
+  });
+  this.client.on('error', (err) => {
+    log.error('error connecting to redis', err);
+  });
   this.server = new Server(this._config.server, this._configureApp());
 
   this._healthInterval = setInterval(() => this._logHealthInfo(),
@@ -124,14 +131,15 @@ Engine.prototype._configureApp = function() {
   log.info('configuring service endpoints');
 
   let self = this;
+  const app = express();
   const routers = Server.Routes({
     config: this._config,
     storage: this.storage,
     network: this.network,
     mailer: this.mailer,
-    contracts: this.contracts
+    contracts: this.contracts,
+    client: this.client
   });
-  const app = express();
 
   function bindRoute(route) {
     let verb = route.shift().toLowerCase();

--- a/lib/server/routefactory.js
+++ b/lib/server/routefactory.js
@@ -14,7 +14,8 @@ module.exports = function RouteFactory(options) {
       network: options.network,
       storage: options.storage,
       mailer: options.mailer,
-      contracts: options.contracts
+      contracts: options.contracts,
+      client: options.client
     }).getEndpointDefinitions();
   }).reduce(function(set1, set2) {
     return set1.concat(set2);

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -9,9 +9,9 @@ const errors = require('storj-service-error-types');
 const merge = require('merge');
 const inherits = require('util').inherits;
 const authenticate = middleware.authenticate;
+const limiter = middleware.rateLimiter;
 const crypto = require('crypto');
 const storj = require('storj-lib');
-
 /**
  * Handles endpoints for all user related operations
  * @constructor
@@ -25,6 +25,22 @@ function UsersRouter(options) {
   Router.apply(this, arguments);
 
   this._verify = authenticate(this.storage);
+
+  /**
+   * Defaults for rate limiter
+   */
+  this._defaults = {
+    lookup: function(req) {
+      return [req.user, req.connection.remoteAddress]
+    },
+    onRateLimited: function(req, res, next) {
+      log.info('user rate limited', req.user, req.connection.remoteAddress);
+      return next(new errors.BadRequestError('Slow down, dude.'));
+    },
+    total: 1,
+    expire: 1000 * 60 // 1 minutes
+  };
+  this._limiter = middleware.rateLimiter(options.client);
 }
 
 inherits(UsersRouter, Router);
@@ -385,7 +401,7 @@ UsersRouter.prototype.confirmPasswordReset = function(req, res, next) {
  */
 UsersRouter.prototype._definitions = function() {
   return [
-    ['POST', '/users', rawbody, this.createUser],
+    ['POST', '/users', this._limiter(this._defaults), rawbody, this.createUser],
     ['POST', '/activations', rawbody, this.reactivateUser],
     ['GET', '/activations/:token', this.confirmActivateUser],
     ['DELETE', '/users/:id', this._verify, this.destroyUser],

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "nodemailer": "^2.0.0",
     "rc": "^1.1.6",
     "readable-stream": "^2.0.5",
+    "redis": "^2.7.1",
     "storj-complex": "^5.0.0",
     "storj-lib": "^6.2.0",
     "storj-mongodb-adapter": "^7.0.1",


### PR DESCRIPTION
- Setup redis instance
- Pass redis client through to routes
- Set limiter defaults in route constructor
- Declare rate limiter in definition block of routes

Example route is in UsersRouter. I just wanted to push up how the rate limiter implementation will look. This is a working example. If you want to test it, just create a redis container locally 

`docker run --name redis -p 6379:6379 -d redis` 

and then start the bridge server as you normally would. The example is in the users router and the.

TODO:
- Add auth config to Redis `createClient`
- Start redis with `--auth`
- Integrate redis into storj-sdk for development
- Add tests for added code and get back up to 100% coverage