### PR TITLE
Erasure encoding updates

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1067,12 +1067,7 @@ BucketsRouter.prototype._getPointersFromEntry = function(entry, opts,
     async.mapLimit(pointers, 6, function(sPointer, next) {
       self._getRetrievalToken(sPointer, {
         excludeFarmers: opts.excludeFarmers
-      }, (err, result) => {
-        if (err) {
-          return next(err);
-        }
-        next(null, result);
-      });
+      }, next);
     }, function(err, results) {
       if (err) {
         return done(new errors.InternalError(err.message));

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1316,7 +1316,8 @@ BucketsRouter.prototype.getFileInfo = function(req, res, next) {
         size: entry.frame.size,
         id: entry._id,
         created: entry.created,
-        hmac: entry.hmac
+        hmac: entry.hmac,
+        erasure: entry.erasure
       });
     });
   });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -464,7 +464,8 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
         frame: frame._id,
         mimetype: req.body.mimetype,
         name: req.body.filename,
-        hmac: req.body.hmac
+        hmac: req.body.hmac,
+        erasure: req.body.erasure
       }, function(err, entry) {
         if (err) {
           return next(new errors.InternalError(err.message));

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -885,7 +885,7 @@ BucketsRouter.prototype._getRetrievalToken = function(sPointer, opts, done) {
           new errors.ServiceUnavailableError('Timed out waiting for pointers')
         );
         finalHandlerAlreadyCalled = true;
-      }, 10000);
+      }, 20000);
 
       function handleResults(err, result) {
         if (finalHandlerAlreadyCalled) {
@@ -895,18 +895,27 @@ BucketsRouter.prototype._getRetrievalToken = function(sPointer, opts, done) {
         finalHandlerAlreadyCalled = true;
         clearTimeout(retrievalTimeout);
 
+        let data = {
+          index: sPointer.index,
+          hash: sPointer.hash,
+          size: sPointer.size,
+          parity: sPointer.parity
+        };
+
+        // We want to return the result even if there was a failure
+        // to retrieve the token from the farmer, it will just be missing
+        // a token and farmer contact.
         if (err || !result) {
-          log.error(
+          log.warn(
             'Failed to get retrieval token, %s',
             err ? err.message : 'No farmers responded'
           );
-          return done(
-            new errors.ServiceUnavailableError('Failed to get retrieval token')
-          );
+        } else {
+          data.token = result.pointer.token;
+          data.farmer = result.pointer.farmer;
+          data.operation = 'PULL';
         }
-
-        result.pointer.size = sPointer.size;
-        done(null, result.pointer);
+        done(null, data);
       }
 
       async.detectLimit(
@@ -972,9 +981,7 @@ BucketsRouter.prototype._requestRetrievalPointer = function(item, meta, done) {
 
       meta.pointer = {
         token: dcPointer.token,
-        hash: item.hash,
-        farmer: meta.contact,
-        operation: 'PULL'
+        farmer: meta.contact
       };
 
       done(null, true);
@@ -1064,8 +1071,6 @@ BucketsRouter.prototype._getPointersFromEntry = function(entry, opts,
         if (err) {
           return next(err);
         }
-
-        result.index = sPointer.index;
         next(null, result);
       });
     }, function(err, results) {

--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -159,6 +159,7 @@ FramesRouter.prototype.addShardToFrame = function(req, res, next) {
       hash: req.body.hash,
       size: req.body.size,
       tree: req.body.tree,
+      parity: req.body.parity,
       challenges: req.body.challenges
     };
 

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -2097,26 +2097,28 @@ describe('BucketsRouter', function() {
   });
 
   describe('#_getRetrievalToken', function() {
+    const sandbox = sinon.sandbox.create();
+    afterEach(() => sandbox.restore());
 
     it('should internal error if contract cannot load', function(done) {
-      var _load = sinon.stub(
+      var _load = sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, new Error('Failed to load item'));
       bucketsRouter._getRetrievalToken({}, {}, function(err) {
-        _load.restore();
         expect(err.message).to.equal('Failed to load item');
         done();
       });
     });
 
-    it('should callback after timeout and not double', function(done) {
-      var _load = sinon.stub(
+    it('should callback after timeout, not double, w/ data', function(done) {
+      sandbox.stub(log, 'warn');
+      var _load = sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, new storj.StorageItem({}));
-      var clock = sinon.useFakeTimers();
-      var _contactFind = sinon.stub(
+      var clock = sandbox.useFakeTimers();
+      var _contactFind = sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, null, [
@@ -2126,45 +2128,57 @@ describe('BucketsRouter', function() {
           port: 1234
         })
       ]);
-      var _requestRetrievalPointer = sinon.stub(
+      var _requestRetrievalPointer = sandbox.stub(
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, meta, cb) {
           setTimeout(cb, 12000);
         }
       );
-      bucketsRouter._getRetrievalToken({}, {}, function(err) {
-        _contactFind.restore();
-        _load.restore();
+      const sPointer = {
+        index: 12,
+        hash: 'shardhash',
+        size: 65536,
+        parity: true
+      };
+      bucketsRouter._getRetrievalToken(sPointer, {}, function(err, result) {
         setImmediate(() => {
-          clock.restore();
-          _requestRetrievalPointer.restore();
-          expect(err.message).to.equal('Failed to get retrieval token');
+          if (err) {
+            return done(err);
+          }
+          expect(result).to.eql({
+            index: 12,
+            hash: 'shardhash',
+            size: 65536,
+            parity: true
+          });
+          expect(log.warn.callCount).to.equal(1);
+          expect(result.token).to.equal(undefined);
+          expect(result.operation).to.equal(undefined);
+          expect(result.farmer).to.equal(undefined);
           done();
         });
       });
-      clock.tick(12000);
+      clock.tick(22000);
     });
 
     it('should callback error if query fails', function(done) {
-      var _load = sinon.stub(
+      var _load = sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, new storj.StorageItem({}));
-      var _contactFind = sinon.stub(
+      var _contactFind = sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, new Error('Query failed'));
       bucketsRouter._getRetrievalToken({}, {}, function(err) {
-        _contactFind.restore();
-        _load.restore();
         expect(err.message).to.equal('Query failed');
         done();
       });
     });
 
-    it('should internal error if no token retrieved', function(done) {
-      var _load = sinon.stub(
+    it('should log error if no token retrieved, give w/ data', function(done) {
+      var _load = sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, storj.StorageItem({
@@ -2175,7 +2189,7 @@ describe('BucketsRouter', function() {
           nodeid3: { data_hash: storj.utils.rmd160('') }
         }
       }));
-      var _contactFind = sinon.stub(
+      var _contactFind = sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, null, [
@@ -2198,26 +2212,37 @@ describe('BucketsRouter', function() {
           lastSeen: 12
         })
       ]);
-      var _requestRetrievalPointer = sinon.stub(
+      var _requestRetrievalPointer = sandbox.stub(
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, options, next) {
           next();
         }
       );
-      bucketsRouter._getRetrievalToken({}, {
+      const sPointer = {
+        index: 12,
+        hash: 'shardhash',
+        size: 65536,
+        parity: true
+      };
+      bucketsRouter._getRetrievalToken(sPointer, {
         excludeFarmers: ['nodeid3']
-      }, function(err) {
-        _contactFind.restore();
-        _load.restore();
-        _requestRetrievalPointer.restore();
-        expect(err.message).to.equal('Failed to get retrieval token');
+      }, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        expect(result).to.eql({
+          index: 12,
+          hash: 'shardhash',
+          size: 65536,
+          parity: true
+        });
         done();
       });
     });
 
     it('should callback with pointer when received', function(done) {
-      var _load = sinon.stub(
+      var _load = sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, storj.StorageItem({
@@ -2228,7 +2253,7 @@ describe('BucketsRouter', function() {
           nodeid3: { data_hash: storj.utils.rmd160('') }
         }
       }));
-      var _requestRetrievalPointer = sinon.stub(
+      var _requestRetrievalPointer = sandbox.stub(
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, options, next) {
@@ -2240,7 +2265,7 @@ describe('BucketsRouter', function() {
           next(null, true);
         }
       );
-      var _contactFind = sinon.stub(
+      var _contactFind = sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, null, [
@@ -2267,9 +2292,6 @@ describe('BucketsRouter', function() {
       bucketsRouter._getRetrievalToken({}, {
         excludeFarmers: ['nodeid3']
       }, function(err, result) {
-        _load.restore();
-        _contactFind.restore();
-        _requestRetrievalPointer.restore();
         expect(result.token).to.equal('correct token');
         done();
       });
@@ -2395,9 +2417,7 @@ describe('BucketsRouter', function() {
         ).to.equal(1);
         expect(err).to.equal(null);
         expect(meta.pointer.token).to.equal('token');
-        expect(meta.pointer.hash).to.equal(storj.utils.rmd160(''));
         expect(meta.pointer.farmer.nodeID).to.equal(storj.utils.rmd160('nodeid'));
-        expect(meta.pointer.operation).to.equal('PULL');
         done();
       });
     });

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -4063,7 +4063,7 @@ it('should throw error on storage event save failure', function(done) {
         expect(response._getData().filename).to.equal('package.json');
         expect(response._getData().erasure).to.eql({
           type: 'reedsolomon'
-        })
+        });
         expect(response._getData().hmac).to.eql({
           type: 'sha512',
           value: 'f891be8e91491e4aeeb193e9e3afb49e83b6cc18df2be9732dd62545' +

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -1507,6 +1507,9 @@ describe('BucketsRouter', function() {
               'ec5d318076ef86adc5771dc4b7b1ce8802bb3b9dce9f7c5a438afd1b1f52f' +
               'b5e37e3f5c8',
             type: 'sha512'
+          },
+          erasure: {
+            type: 'reedsolomon'
           }
         },
         params: {
@@ -1560,6 +1563,9 @@ describe('BucketsRouter', function() {
             value: 'f891be8e91491e4aeeb193e9e3afb49e83b6cc18df2be9732dd62545' +
               'ec5d318076ef86adc5771dc4b7b1ce8802bb3b9dce9f7c5a438afd1b1f52f' +
               'b5e37e3f5c8'
+          },
+          erasure: {
+            type: 'reedsolomon'
           },
           mimetype: 'application/octet-stream',
           name: 'somefilename'

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -2132,7 +2132,7 @@ describe('BucketsRouter', function() {
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, meta, cb) {
-          setTimeout(cb, 12000);
+          setTimeout(cb, 22000);
         }
       );
       const sPointer = {

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -4050,6 +4050,9 @@ it('should throw error on storage event save failure', function(done) {
             value: 'f891be8e91491e4aeeb193e9e3afb49e83b6cc18df2be9732dd62545' +
               'ec5d318076ef86adc5771dc4b7b1ce8802bb3b9dce9f7c5a438afd1b1f52f' +
               'b5e37e3f5c8'
+          },
+          erasure: {
+            type: 'reedsolomon'
           }
         })
       });
@@ -4058,6 +4061,9 @@ it('should throw error on storage event save failure', function(done) {
         _bucketEntryFindOne.restore();
         expect(response._getData().created).to.equal('2017-03-22T19:54:34.146Z');
         expect(response._getData().filename).to.equal('package.json');
+        expect(response._getData().erasure).to.eql({
+          type: 'reedsolomon'
+        })
         expect(response._getData().hmac).to.eql({
           type: 'sha512',
           value: 'f891be8e91491e4aeeb193e9e3afb49e83b6cc18df2be9732dd62545' +

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -2101,7 +2101,7 @@ describe('BucketsRouter', function() {
     afterEach(() => sandbox.restore());
 
     it('should internal error if contract cannot load', function(done) {
-      var _load = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, new Error('Failed to load item'));
@@ -2113,12 +2113,12 @@ describe('BucketsRouter', function() {
 
     it('should callback after timeout, not double, w/ data', function(done) {
       sandbox.stub(log, 'warn');
-      var _load = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, new storj.StorageItem({}));
       var clock = sandbox.useFakeTimers();
-      var _contactFind = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, null, [
@@ -2128,7 +2128,7 @@ describe('BucketsRouter', function() {
           port: 1234
         })
       ]);
-      var _requestRetrievalPointer = sandbox.stub(
+      sandbox.stub(
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, meta, cb) {
@@ -2163,11 +2163,11 @@ describe('BucketsRouter', function() {
     });
 
     it('should callback error if query fails', function(done) {
-      var _load = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, new storj.StorageItem({}));
-      var _contactFind = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, new Error('Query failed'));
@@ -2178,7 +2178,7 @@ describe('BucketsRouter', function() {
     });
 
     it('should log error if no token retrieved, give w/ data', function(done) {
-      var _load = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, storj.StorageItem({
@@ -2189,7 +2189,7 @@ describe('BucketsRouter', function() {
           nodeid3: { data_hash: storj.utils.rmd160('') }
         }
       }));
-      var _contactFind = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, null, [
@@ -2212,7 +2212,7 @@ describe('BucketsRouter', function() {
           lastSeen: 12
         })
       ]);
-      var _requestRetrievalPointer = sandbox.stub(
+      sandbox.stub(
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, options, next) {
@@ -2242,7 +2242,7 @@ describe('BucketsRouter', function() {
     });
 
     it('should callback with pointer when received', function(done) {
-      var _load = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.contracts,
         'load'
       ).callsArgWith(1, null, storj.StorageItem({
@@ -2253,7 +2253,7 @@ describe('BucketsRouter', function() {
           nodeid3: { data_hash: storj.utils.rmd160('') }
         }
       }));
-      var _requestRetrievalPointer = sandbox.stub(
+      sandbox.stub(
         bucketsRouter,
         '_requestRetrievalPointer',
         function(item, options, next) {
@@ -2265,7 +2265,7 @@ describe('BucketsRouter', function() {
           next(null, true);
         }
       );
-      var _contactFind = sandbox.stub(
+      sandbox.stub(
         bucketsRouter.storage.models.Contact,
         'find'
       ).callsArgWith(1, null, [

--- a/test/server/routes/frames.unit.js
+++ b/test/server/routes/frames.unit.js
@@ -709,6 +709,7 @@ describe('FramesRouter', function() {
           index: 0,
           hash: storj.utils.rmd160('data'),
           size: 1024 * 1024 * 8,
+          parity: true,
           challenges: auditStream.getPrivateRecord().challenges,
           tree: auditStream.getPublicRecord()
         }
@@ -782,6 +783,16 @@ describe('FramesRouter', function() {
         _getConsign.restore();
         _frameSave.restore();
         var result = response._getData();
+
+        expect(_pointerCreate.callCount).to.equal(1);
+        expect(_pointerCreate.args[0][0].challenges.length).to.equal(3);
+        expect(_pointerCreate.args[0][0].hash)
+          .to.equal('cd43325b85172ca28e96785d0cb4832fd62cdf43');
+        expect(_pointerCreate.args[0][0].index).to.equal(0);
+        expect(_pointerCreate.args[0][0].parity).to.equal(true);
+        expect(_pointerCreate.args[0][0].size).to.equal(8388608);
+        expect(_pointerCreate.args[0][0].tree.length).to.equal(4);
+
         expect(result.farmer.nodeID).to.equal(storj.utils.rmd160('farmer'));
         expect(result.hash).to.equal(storj.utils.rmd160('data'));
         expect(result.token).to.equal('token');


### PR DESCRIPTION
Todo:
- [x] Return pointers even if a token was not able to be fetched, as now they can be missing for `getFile`
- [x] Return pointer with parity info for `getFile`
- [x] Be able to specify that a shard is a parity on upload for `addShardToFrame`
- [x] Return back erasure code type in bucket entry data for `getFileInfo`
- [x] Test w/ [libstorj](https://github.com/Storj/libstorj/issues/274)
- [ ] Update package.json w/ released version of updated storj-service-storage-models

Depends: https://github.com/Storj/service-storage-models/pull/90
Part of: https://github.com/Storj/libstorj/issues/274