### PR TITLE
Remove reference to non-returned user fields

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1127,7 +1127,12 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
         log.warn('getFile: Transfer rate limited, user: %s', user.email);
         analytics.track(req.headers.dnt, {
           userId: user.uuid,
-          event: 'User Download Rate Limited'
+          event: 'User Download Rate Limited',
+          properties: {
+            monthlyBytes: user.bytesDownloaded.lastMonthBytes,
+            dailyBytes: user.bytesDownloaded.lastDayBytes,
+            hourlyBytes: user.bytesDownloaded.lastHourBytes
+          }
         });
         return next(new errors.TransferRateError(
           'Could not get file, transfer rate limit reached.'

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1127,10 +1127,7 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
         log.warn('getFile: Transfer rate limited, user: %s', user.email);
         analytics.track(req.headers.dnt, {
           userId: user.uuid,
-          event: 'User Download Rate Limited',
-          properties: {
-            bytesDownloaded: user.bytesDownloaded
-          }
+          event: 'User Download Rate Limited'
         });
         return next(new errors.TransferRateError(
           'Could not get file, transfer rate limit reached.'

--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -44,7 +44,12 @@ FramesRouter.prototype.createFrame = function(req, res, next) {
     log.warn('createFrame: Transfer rate limited, user: %s', req.user.email);
     analytics.track(req.headers.dnt, {
       userId: req.user.uuid,
-      event: 'User Upload Rate Limited'
+      event: 'User Upload Rate Limited',
+      properties: {
+        monthlyBytes: req.user.bytesUploaded.lastMonthBytes,
+        dailyBytes: req.user.bytesUploaded.lastDayBytes,
+        hourlyBytes: req.user.bytesUploaded.lastHourBytes
+      }
     });
     return next(new errors.TransferRateError(
       'Could not create frame, transfer rate limit reached.'

--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -44,10 +44,7 @@ FramesRouter.prototype.createFrame = function(req, res, next) {
     log.warn('createFrame: Transfer rate limited, user: %s', req.user.email);
     analytics.track(req.headers.dnt, {
       userId: req.user.uuid,
-      event: 'User Upload Rate Limited',
-      properties: {
-        bytesUploaded: req.user.bytesUploaded
-      }
+      event: 'User Upload Rate Limited'
     });
     return next(new errors.TransferRateError(
       'Could not create frame, transfer rate limit reached.'


### PR DESCRIPTION
Fixes error when rate limiting users.

`bytesUploaded` and `bytesDownloaded` are not part of the returned user object. This caused an unintentional node error message to hijack the intended rate limiting error message.