### PR TITLE
Health check endpoint

### DIFF
--- a/lib/server/routefactory.js
+++ b/lib/server/routefactory.js
@@ -7,14 +7,16 @@ module.exports = function RouteFactory(options) {
     require('./routes/users'),
     require('./routes/frames'),
     require('./routes/contacts'),
-    require('./routes/reports')
+    require('./routes/reports'),
+    require('./routes/health')
   ]).map(function(Router) {
     return Router({
       config: options.config,
       network: options.network,
       storage: options.storage,
       mailer: options.mailer,
-      contracts: options.contracts
+      contracts: options.contracts,
+      redis: options.redis
     }).getEndpointDefinitions();
   }).reduce(function(set1, set2) {
     return set1.concat(set2);

--- a/lib/server/routes/health.js
+++ b/lib/server/routes/health.js
@@ -1,9 +1,7 @@
 'use strict';
 
-const middleware = require('storj-service-middleware');
 const Router = require('./index');
 const inherits = require('util').inherits;
-const rawbody = middleware.rawbody;
 
 function HealthRouter(options) {
   if(!(this instanceof HealthRouter)) {

--- a/lib/server/routes/health.js
+++ b/lib/server/routes/health.js
@@ -14,11 +14,11 @@ function HealthRouter(options) {
 inherits(HealthRouter, Router);
 
 HealthRouter.prototype.health = function(req, res) {
-  if (!this.storage) {
-    res.status(503).send('Service Unavailable');
+  if (this.storage.connection.readyState === 1) {
+    res.status(200).send('OK');
   }
 
-  res.status(200).send('OK');
+  res.status(503).send('Service Unavailable');
 };
 
 HealthRouter.prototype._definitions = function() {

--- a/lib/server/routes/health.js
+++ b/lib/server/routes/health.js
@@ -11,19 +11,22 @@ function HealthRouter(options) {
   }
 
   Router.apply(this, arguments);
-
 }
 
 inherits(HealthRouter, Router);
 
-HealthRouter.prototype.health = function(req, res, next) {
+HealthRouter.prototype.health = function(req, res) {
+  if (!this.storage) {
+    res.status(503).send('Service Unavailable');
+  }
+
   res.status(200).send('OK');
-}
+};
 
 HealthRouter.prototype._definitions = function() {
   return [
-    ['GET', '/health', rawbody, this.health]
-  ]
-}
+    ['GET', '/health', this.health]
+  ];
+};
 
 module.exports = HealthRouter;

--- a/lib/server/routes/health.js
+++ b/lib/server/routes/health.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const middleware = require('storj-service-middleware');
+const Router = require('./index');
+const inherits = require('util').inherits;
+const rawbody = middleware.rawbody;
+
+function HealthRouter(options) {
+  if(!(this instanceof HealthRouter)) {
+    return new HealthRouter(options);
+  }
+
+  Router.apply(this, arguments);
+
+}
+
+inherits(HealthRouter, Router);
+
+HealthRouter.prototype.health = function(req, res, next) {
+  res.status(200).send('OK');
+}
+
+HealthRouter.prototype._definitions = function() {
+  return [
+    ['GET', '/health', rawbody, this.health]
+  ]
+}
+
+module.exports = HealthRouter;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-bridge",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "description": "Access the Storj network using a simple REST API.",
   "main": "index.js",
   "directories": {

--- a/test/server/routes/buckets.integration.js
+++ b/test/server/routes/buckets.integration.js
@@ -55,7 +55,6 @@ describe('BucketsRouter Integration', function() {
 
 
       req.on('response', (res) => {
-        console.log('res', res);
         expect(res.statusCode).to.equal(400);
         res
           .on('data', (data) => {

--- a/test/server/routes/health.unit.js
+++ b/test/server/routes/health.unit.js
@@ -8,7 +8,7 @@ const EventEmitter = require('events').EventEmitter;
 describe('HealthRouter', function() {
   const healthRouter = new HealthRouter(
     require('../../_fixtures/router-opts')
-  )
+  );
 
   describe('#health', function() {
 
@@ -48,6 +48,6 @@ describe('HealthRouter', function() {
         });
 
         healthRouter.health(req, res);
-      })
-  })
-})
+      });
+  });
+});

--- a/test/server/routes/health.unit.js
+++ b/test/server/routes/health.unit.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const HealthRouter = require('../../../lib/server/routes/health');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const httpMocks = require('node-mocks-http');
+
+describe('HealthRouter', function() {
+  var healthRouter = new HealthRouter(
+    require('../../_fixtures/router-opts')
+  )
+
+  describe('#health', function() {
+
+      it('should return 200 if everything ok', function(done) {
+
+        done();
+      })
+  })
+})

--- a/test/server/routes/health.unit.js
+++ b/test/server/routes/health.unit.js
@@ -2,19 +2,52 @@
 
 const HealthRouter = require('../../../lib/server/routes/health');
 const expect = require('chai').expect;
-const sinon = require('sinon');
 const httpMocks = require('node-mocks-http');
+const EventEmitter = require('events').EventEmitter;
 
 describe('HealthRouter', function() {
-  var healthRouter = new HealthRouter(
+  const healthRouter = new HealthRouter(
     require('../../_fixtures/router-opts')
   )
 
   describe('#health', function() {
 
       it('should return 200 if everything ok', function(done) {
+        const req = httpMocks.createRequest({
+          method: 'GET',
+          url: '/health'
+        });
+        const res = httpMocks.createResponse({
+          req: req,
+          eventEmitter: EventEmitter
+        });
 
-        done();
+        res.on('end', function() {
+          expect(res._getData()).to.equal('OK');
+          done();
+        });
+
+        healthRouter.health(req, res);
+      });
+
+      it('should return 503 if health check fails', function(done) {
+        const req = httpMocks.createRequest({
+          method: 'GET',
+          url: '/health'
+        });
+        const res = httpMocks.createResponse({
+          req: req,
+          eventEmitter: EventEmitter
+        });
+
+        healthRouter.storage = undefined;
+
+        res.on('end', function() {
+          console.log('res._getData()', res._getData());
+          done();
+        });
+
+        healthRouter.health(req, res);
       })
   })
 })


### PR DESCRIPTION
add `/health` endpoint that checks database status and returns `503 Service Unavailable` if database down, `200 OK` if everything else is golden. 

Not sure if we want any other metrics or data returned in this, I just went for dead simple to start with. 

Closes https://github.com/Storj/bridge/issues/329