### PR TITLE
[WiP] add user.preferences.dnt to analytics calls

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -134,7 +134,7 @@ BucketsRouter.prototype.createBucket = function(req, res, next) {
     return next(new errors.BadRequestError('Invalid public key supplied'));
   }
 
-  analytics.track(req.headers.dnt, {
+  analytics.track(req.headers.dnt || req.user.preferences.dnt, {
     userId: req.user.uuid,
     event: 'Bucket Created'
   });
@@ -163,7 +163,7 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
 
   log.info('removing bucket %s for %s', req.params.id, req.user._id);
 
-  analytics.track(req.headers.dnt, {
+  analytics.track(req.headers.dnt || req.user.preferences.dnt, {
     userId: req.user.uuid,
     event: 'Bucket Destroyed'
   });
@@ -367,7 +367,7 @@ BucketsRouter.prototype.createBucketToken = function(req, res, next) {
 
     log.info('creating %s token for %s', req.body.operation, req.params.id);
 
-    analytics.track(req.headers.dnt, {
+    analytics.track(req.headers.dnt || req.user.preferences.dnt, {
       userId: req.user.uuid,
       event: 'Token Created',
       properties: {
@@ -424,7 +424,7 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
     return next(new errors.BadRequestError('Maximum bucket entry name'));
   }
 
-  analytics.track(req.headers.dnt, {
+  analytics.track(req.headers.dnt || req.user.preferences.dnt, {
     userId: req.user.uuid,
     event: 'File Upload Complete'
   });
@@ -1125,7 +1125,7 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
                                      rates.monthlyBytes)) {
 
         log.warn('getFile: Transfer rate limited, user: %s', user.email);
-        analytics.track(req.headers.dnt, {
+        analytics.track(req.headers.dnt || req.user.preferences.dnt, {
           userId: user.uuid,
           event: 'User Download Rate Limited',
           properties: {
@@ -1139,7 +1139,7 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
         ));
       }
 
-      analytics.track(req.headers.dnt, {
+      analytics.track(req.headers.dnt || req.user.preferences.dnt, {
         userId: user.uuid,
         event: 'File Pointers Retrieved'
       });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1125,7 +1125,7 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
                                      rates.monthlyBytes)) {
 
         log.warn('getFile: Transfer rate limited, user: %s', user.email);
-        analytics.track(req.headers.dnt || req.user.preferences.dnt, {
+        analytics.track(req.headers.dnt || user.preferences.dnt, {
           userId: user.uuid,
           event: 'User Download Rate Limited',
           properties: {
@@ -1139,7 +1139,7 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
         ));
       }
 
-      analytics.track(req.headers.dnt || req.user.preferences.dnt, {
+      analytics.track(req.headers.dnt || user.preferences.dnt, {
         userId: user.uuid,
         event: 'File Pointers Retrieved'
       });

--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -42,7 +42,7 @@ FramesRouter.prototype.createFrame = function(req, res, next) {
                                    rates.dailyBytes,
                                    rates.monthlyBytes)) {
     log.warn('createFrame: Transfer rate limited, user: %s', req.user.email);
-    analytics.track(req.headers.dnt, {
+    analytics.track(req.headers.dnt || req.user.preferences.dnt, {
       userId: req.user.uuid,
       event: 'User Upload Rate Limited',
       properties: {
@@ -56,7 +56,7 @@ FramesRouter.prototype.createFrame = function(req, res, next) {
     ));
   }
 
-  analytics.track(req.headers.dnt, {
+  analytics.track(req.headers.dnt || req.user.preferences.dnt, {
     userId: req.user.uuid,
     event: 'Frame Created'
   });
@@ -123,7 +123,7 @@ FramesRouter.prototype.addShardToFrame = function(req, res, next) {
                                    rates.dailyBytes,
                                    rates.monthlyBytes)) {
     log.warn('addShardToFrame: Transfer rate limited, user: %s', req.user.email);
-    analytics.track(req.headers.dnt, {
+    analytics.track(req.headers.dnt || req.user.preferences.dnt, {
       userId: req.user.uuid,
       event: 'User Upload Rate Limited',
       properties: {

--- a/lib/server/routes/pubkeys.js
+++ b/lib/server/routes/pubkeys.js
@@ -58,7 +58,7 @@ PublicKeysRouter.prototype.addPublicKey = function(req, res, next) {
 
   log.info('registering public key for %s', req.user._id);
 
-  analytics.track(req.headers.dnt, {
+  analytics.track(req.headers.dnt || req.user.preferences.dnt, {
     userId: req.user.uuid,
     event: 'Key Registered'
   });
@@ -93,7 +93,7 @@ PublicKeysRouter.prototype.destroyPublicKey = function(req, res, next) {
 
   log.info('destroying public key for %s', req.user._id);
 
-  analytics.track(req.headers.dnt, {
+  analytics.track(req.headers.dnt || req.user.preferences.dnt, {
     userId: req.user.uuid,
     event: 'Key Destroyed'
   });

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -81,13 +81,13 @@ UsersRouter.prototype.createUser = function(req, res, next) {
       return next(err);
     }
 
-    analytics.identify(req.headers.dnt || req.user.preferences.dnt, {
+    analytics.identify(req.headers.dnt, {
       userId: user.uuid,
       traits: {
         activated: false
       }
     });
-    analytics.track(req.headers.dnt || req.user.preferences.dnt, {
+    analytics.track(req.headers.dnt, {
       userId: user.uuid,
       event: 'User Created'
     });
@@ -138,11 +138,11 @@ UsersRouter.prototype.confirmActivateUser = function(req, res, next) {
         return next(new errors.InternalError(err.message));
       }
 
-      analytics.track(req.headers.dnt || req.user.preferences.dnt, {
+      analytics.track(req.headers.dnt || user.preferences.dnt, {
         userId: user.uuid,
         event: 'User Activated'
       });
-      analytics.identify(req.headers.dnt || req.user.preferences.dnt, {
+      analytics.identify(req.headers.dnt || user.preferences.dnt, {
         userId: user.uuid,
         traits: {
           activated: true

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -81,13 +81,13 @@ UsersRouter.prototype.createUser = function(req, res, next) {
       return next(err);
     }
 
-    analytics.identify(req.headers.dnt, {
+    analytics.identify(req.headers.dnt || req.user.preferences.dnt, {
       userId: user.uuid,
       traits: {
         activated: false
       }
     });
-    analytics.track(req.headers.dnt, {
+    analytics.track(req.headers.dnt || req.user.preferences.dnt, {
       userId: user.uuid,
       event: 'User Created'
     });
@@ -138,11 +138,11 @@ UsersRouter.prototype.confirmActivateUser = function(req, res, next) {
         return next(new errors.InternalError(err.message));
       }
 
-      analytics.track(req.headers.dnt, {
+      analytics.track(req.headers.dnt || req.user.preferences.dnt, {
         userId: user.uuid,
         event: 'User Activated'
       });
-      analytics.identify(req.headers.dnt, {
+      analytics.identify(req.headers.dnt || req.user.preferences.dnt, {
         userId: user.uuid,
         traits: {
           activated: true

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "storj-mongodb-adapter": "^7.0.1",
     "storj-service-error-types": "^1.1.0",
     "storj-service-mailer": "^1.0.0",
-    "storj-service-middleware": "^1.2.1",
+    "storj-service-middleware": "^1.3.0",
     "storj-service-storage-models": "^8.16.1",
     "through": "^2.3.8"
   }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "storj-service-error-types": "^1.1.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.2.1",
-    "storj-service-storage-models": "^8.15.0",
+    "storj-service-storage-models": "^8.16.1",
     "through": "^2.3.8"
   }
 }


### PR DESCRIPTION
Adds `user.preferences.dnt` to analytics calls.

Todo:

- [ ]  Migration script to add preferences object to existing users
- [ ] Add some way for users to set the dnt preference
