### PR TITLE
Deprecate deterministic bucket_id and file_id

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -473,7 +473,8 @@ BucketsRouter.prototype.createEntryFromFrame = function(req, res, next) {
         mimetype: req.body.mimetype,
         name: req.body.filename,
         hmac: req.body.hmac,
-        erasure: req.body.erasure
+        erasure: req.body.erasure,
+        index: req.body.index
       }, function(err, entry) {
         if (err) {
           return next(new errors.InternalError(err.message));

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1327,7 +1327,8 @@ BucketsRouter.prototype.getFileInfo = function(req, res, next) {
         id: entry._id,
         created: entry.created,
         hmac: entry.hmac,
-        erasure: entry.erasure
+        erasure: entry.erasure,
+        index: entry.index
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "storj-service-error-types": "^1.2.0",
     "storj-service-mailer": "^1.0.0",
     "storj-service-middleware": "^1.3.1",
-    "storj-service-storage-models": "^8.17.0",
+    "storj-service-storage-models": "^8.18.0",
     "through": "^2.3.8"
   }
 }

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -1522,7 +1522,8 @@ describe('BucketsRouter', function() {
           },
           erasure: {
             type: 'reedsolomon'
-          }
+          },
+          index: '0c8b74d283a4d52a32332d622bd66fdf67f7c80eed3a2854da1df0a56f7135bb'
         },
         params: {
           id: 'bucketid'
@@ -1580,7 +1581,8 @@ describe('BucketsRouter', function() {
             type: 'reedsolomon'
           },
           mimetype: 'application/octet-stream',
-          name: 'somefilename'
+          name: 'somefilename',
+          index: '0c8b74d283a4d52a32332d622bd66fdf67f7c80eed3a2854da1df0a56f7135bb'
         });
         expect(response._getData().hmac).to.eql(hmac);
         expect(response._getData().bucket).to.equal('bucketid');

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -4046,6 +4046,8 @@ it('should throw error on storage event save failure', function(done) {
         req: request,
         eventEmitter: EventEmitter
       });
+      const index = '5bcfdacf38f0660efc7910abdc688cc0f7e4d285feb75c769ae8e41' +
+            '4bfd4c386';
       var _getBucketUnregistered = sinon.stub(
         bucketsRouter,
         '_getBucketUnregistered'
@@ -4073,7 +4075,8 @@ it('should throw error on storage event save failure', function(done) {
           },
           erasure: {
             type: 'reedsolomon'
-          }
+          },
+          index: index
         })
       });
       response.on('end', function() {
@@ -4090,6 +4093,7 @@ it('should throw error on storage event save failure', function(done) {
             'ec5d318076ef86adc5771dc4b7b1ce8802bb3b9dce9f7c5a438afd1b1f52f' +
             'b5e37e3f5c8'
         });
+        expect(response._getData().index).to.eql(index);
         done();
       });
       bucketsRouter.getFileInfo(request, response);


### PR DESCRIPTION
Passes `index` from the create bucket entry request to `BucketEntry.create` for the purpose of removing the deterministic file id and having a unique bucket entry id.

Depends: 
- https://github.com/Storj/service-storage-models/pull/92
- https://github.com/Storj/libstorj/pull/286
