### PR TITLE
Get the contract for the source and not the destination

### DIFF
--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -162,7 +162,7 @@ Monitor.prototype._transferShard = function(shard, state, callback) {
 
   let contract = null;
   try {
-    contract = storj.Contract(destination.contract);
+    contract = shard.getContract(source);
   } catch(e) {
     log.warn('Unable to transfer shard, invalid contract: %j',
              destination.contract);

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -377,7 +377,10 @@ describe('Monitor', function() {
       monitor.network = {
         getRetrievalPointer: sinon.stub().callsArgWith(2, new Error('test'))
       };
-      const shard = {};
+      const contract = new storj.Contract();
+      const shard = {
+        getContract: sandbox.stub().returns(contract)
+      };
       const contact = storj.Contact({
         address: '127.0.0.1',
         port: 100000
@@ -399,6 +402,8 @@ describe('Monitor', function() {
           .to.equal(contact);
         expect(monitor.network.getRetrievalPointer.args[0][1])
           .to.be.instanceOf(storj.Contract);
+        expect(monitor.network.getRetrievalPointer.args[0][1])
+          .to.equal(contract);
         expect(log.warn.callCount).to.equal(1);
         expect(monitor._transferShard.callCount).to.equal(2);
         expect(monitor._saveShard.callCount).to.equal(0);
@@ -416,7 +421,10 @@ describe('Monitor', function() {
         getRetrievalPointer: sinon.stub().callsArgWith(2, null, pointer),
         getMirrorNodes: sinon.stub().callsArgWith(2, new Error('timeout'))
       };
-      const shard = {};
+      const contract = new storj.Contract();
+      const shard = {
+        getContract: sandbox.stub().returns(contract)
+      };
       const contact = storj.Contact({
         address: '127.0.0.1',
         port: 100000
@@ -460,7 +468,10 @@ describe('Monitor', function() {
         getRetrievalPointer: sinon.stub().callsArgWith(2, null, pointer),
         getMirrorNodes: sinon.stub().callsArgWith(2, null, {})
       };
-      const shard = {};
+      const contract = new storj.Contract();
+      const shard = {
+        getContract: sandbox.stub().returns(contract)
+      };
       const contact = storj.Contact({
         address: '127.0.0.1',
         port: 100000


### PR DESCRIPTION
There was an issue w/ when the contract for the destination, a mirror, was being sent
into the `getRetrievalPointer` it was trying to send a `RENEW` command to the source
instead of the destination, as the contract didn't have an hd_key. The `RENEW` command
failed at the farmer with an error that the contract can not be changed to a
different farmer.

Closes https://github.com/Storj/bridge/issues/426