### PR TITLE
Add methods for getting bucket and bucket entry ids by name

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -110,7 +110,7 @@ BucketsRouter.prototype.getBucketId = function(req, res, next) {
   Bucket.findOne({
     user: req.user._id,
     name: req.params.name
-  }, '_id', { lean: true }).exec(function(err, bucket) {
+  }, '_id', { lean: true }, function(err, bucket) {
     if (err) {
       return next(new errors.InternalError(err.message));
     }

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -104,6 +104,25 @@ BucketsRouter.prototype.getBucketById = function(req, res, next) {
   });
 };
 
+BucketsRouter.prototype.getBucketId = function(req, res, next) {
+  const Bucket = this.storage.models.Bucket;
+
+  Bucket.findOne({
+    user: req.user._id,
+    name: req.params.name
+  }, '_id', { lean: true }).exec(function(err, bucket) {
+    if (err) {
+      return next(new errors.InternalError(err.message));
+    }
+
+    if (!bucket) {
+      return next(new errors.NotFoundError('Bucket not found'));
+    }
+
+    res.status(200).send({ id: bucket._id });
+  });
+};
+
 /**
  * Creates a new bucket for the user
  * @param {http.IncomingMessage} req
@@ -1087,6 +1106,7 @@ BucketsRouter.prototype._getPointersFromEntry = function(entry, opts,
     });
   });
 };
+
 /**
  * @callback BucketsRouter~_getPointersFromEntryCallback
  * @param {Error|null} [error]
@@ -1298,6 +1318,40 @@ BucketsRouter.prototype.removeFile = function(req, res, next) {
   });
 };
 
+BucketsRouter.prototype.getFileId = function(req, res, next) {
+  const Bucket = this.storage.models.Bucket;
+  const BucketEntry = this.storage.models.BucketEntry;
+
+  Bucket.findOne({
+    _id: req.params.id,
+    user: req.user._id
+  }, '_id', { lean: true }, function(err, bucket) {
+    if (err) {
+      return next(new errors.InternalError(err.message));
+    }
+
+    if (!bucket) {
+      return next(new errors.NotFoundError('Bucket not found'));
+    }
+
+    BucketEntry.findOne({
+      bucket: bucket._id,
+      name: req.params.name
+    }, '_id', { lean: true }, function(err, entry) {
+      if (err) {
+        return next(new errors.InternalError(err.message));
+      }
+
+      if (!entry) {
+        return next(new errors.NotFoundError('File not found'));
+      }
+      res.status(200).send({ id: entry._id });
+    });
+  });
+
+};
+
+
 BucketsRouter.prototype.getFileInfo = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
 
@@ -1343,11 +1397,13 @@ BucketsRouter.prototype._definitions = function() {
   return [
     ['GET', '/buckets', this._limiter(defaults), this._verify, this.getBuckets],
     ['GET', '/buckets/:id', this._limiter(defaults), this._validate, this._verify, this.getBucketById],
+    ['GET', '/bucket-ids/:name', this._limiter(defaults), this._validate, this._verify, this.getBucketId],
     ['POST', '/buckets', this._limiter(defaults), this._verify, this.createBucket],
     ['DELETE', '/buckets/:id', this._limiter(defaults), this._validate, this._verify, this.destroyBucketById],
     ['PATCH', '/buckets/:id', this._limiter(defaults), this._validate, this._verify, this.updateBucketById],
     ['POST', '/buckets/:id/tokens', this._limiter(defaults), this._validate, this._verify, this.createBucketToken],
     ['GET', '/buckets/:id/files', this._limiter(defaults), this._validate, this._verify, this.listFilesInBucket],
+    ['GET', '/buckets/:id/file-ids/:name', this._limiter(defaults), this._validate, this._verify, this.getFileId],
     ['GET', '/buckets/:id/files/:file', this._limiter(defaults), this._validate, this._usetoken, this.getFile],
     ['DELETE', '/buckets/:id/files/:file', this._limiter(defaults), this._validate, this._verify, this.removeFile],
     ['GET', '/buckets/:id/files/:file/info', this._limiter(defaults), this._validate, this.getFileInfo],

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -245,8 +245,85 @@ describe('BucketsRouter', function() {
 
 
   describe('#getBucketId', function() {
-    it('', function() {
+    const sandbox = sinon.sandbox.create();
+    afterEach(() => sandbox.restore());
+
+    it('give internal error', function(done) {
+      const request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/bucket-ids/:name',
+        params: {
+          name: 'base64encryptedbucketname'
+        }
+      });
+      request.user = someUser;
+      const response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, new Error('test'));
+      bucketsRouter.getBucketId(request, response, function(err) {
+        expect(err).to.be.instanceOf(errors.InternalError);
+        expect(err.message).to.equal('test');
+        done();
+      });
     });
+
+    it('give notfound error', function(done) {
+      const request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/bucket-ids/:name',
+        params: {
+          name: 'base64encryptedbucketname'
+        }
+      });
+      request.user = someUser;
+      const response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, null, null);
+      bucketsRouter.getBucketId(request, response, function(err) {
+        expect(err).to.be.instanceOf(errors.NotFoundError);
+        expect(err.message).to.equal('Bucket not found');
+        done();
+      });
+    });
+
+    it('give bucket id', function(done) {
+      const request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/bucket-ids/:name',
+        params: {
+          name: 'base64encryptedbucketname'
+        }
+      });
+      request.user = someUser;
+      const response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, null, { _id: '368be0816766b28fd5f43af5' });
+      response.on('end', function() {
+        expect(response._getData().id).to.equal('368be0816766b28fd5f43af5');
+        done();
+      });
+      bucketsRouter.getBucketId(request, response, function(err) {
+        if (err) {
+          return done(err);
+        }
+      });
+    });
+
   });
 
   describe('#createBucket', function() {

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -243,6 +243,12 @@ describe('BucketsRouter', function() {
 
   });
 
+
+  describe('#getBucketId', function() {
+    it('', function() {
+    });
+  });
+
   describe('#createBucket', function() {
     const sandbox = sinon.sandbox.create();
     beforeEach(() => sandbox.stub(analytics, 'track'));
@@ -3933,6 +3939,153 @@ it('should throw error on storage event save failure', function(done) {
       bucketsRouter.removeFile(request, response);
     });
 
+  });
+
+  describe('#getFileId', function() {
+    const sandbox = sinon.sandbox.create();
+    afterEach(() => sandbox.restore());
+
+    it('should give internal error', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/buckets/:bucket_id/file-ids/:name',
+        params: {
+          id: 'bucketid',
+          name: 'base64encryptedfilename'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, new Error('Failed to get bucket'));
+      bucketsRouter.getFileId(request, response, function(err) {
+        expect(err).to.be.instanceOf(errors.InternalError);
+        expect(err.message).to.equal('Failed to get bucket');
+        done();
+      });
+    });
+
+    it('should give notfound error', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/buckets/:bucket_id/file-ids/:name',
+        params: {
+          id: 'bucketid',
+          name: 'base64encryptedfilename'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, null, null);
+      bucketsRouter.getFileId(request, response, function(err) {
+        expect(err).to.be.instanceOf(errors.NotFoundError);
+        expect(err.message).to.equal('Bucket not found');
+        done();
+      });
+    });
+
+    it('should give internal error', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/buckets/:bucket_id/file-ids/:name',
+        params: {
+          id: 'bucketid',
+          name: 'base64encryptedfilename'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, null, {});
+      sandbox.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'findOne'
+      ).callsArgWith(3, new Error('test'));
+      bucketsRouter.getFileId(request, response, function(err) {
+        expect(err).to.be.instanceOf(errors.InternalError);
+        expect(err.message).to.equal('test');
+        done();
+      });
+    });
+
+    it('should give notfound error', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/buckets/:bucket_id/file-ids/:name',
+        params: {
+          id: 'bucketid',
+          name: 'base64encryptedfilename'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, null, {});
+      sandbox.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'findOne'
+      ).callsArgWith(3, null, null);
+      bucketsRouter.getFileId(request, response, function(err) {
+        expect(err).to.be.instanceOf(errors.NotFoundError);
+        expect(err.message).to.equal('File not found');
+        done();
+      });
+    });
+
+    it('should give file id', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'GET',
+        url: '/buckets/:bucket_id/file-ids/:name',
+        params: {
+          id: 'bucketid',
+          name: 'base64encryptedfilename'
+        }
+      });
+      request.user = someUser;
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      sandbox.stub(
+        bucketsRouter.storage.models.Bucket,
+        'findOne'
+      ).callsArgWith(3, null, {});
+      sandbox.stub(
+        bucketsRouter.storage.models.BucketEntry,
+        'findOne'
+      ).callsArgWith(3, null, { _id: '998960317b6725a3f8080c2b'});
+      response.on('end', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response._getData().id).to.equal('998960317b6725a3f8080c2b');
+        done();
+      });
+      bucketsRouter.getFileId(request, response, function(err) {
+        if (err) {
+          return done(err);
+        }
+      });
+    });
   });
 
   describe('#getFileInfo', function() {


### PR DESCRIPTION
- Adds unique index for bucket name and bucket entry name to avoid unresolvable ambiguity at the application
- Adds endpoint to check that a name does not already exist

Todo:
- [ ] Update package.json with released version of storj-service-storage-models w/ indexes

Depends: https://github.com/Storj/service-storage-models/pull/97