### PR TITLE
Improve logging and errors

### DIFF
--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -194,14 +194,13 @@ FramesRouter.prototype.addShardToFrame = function(req, res, next) {
 
       let bl = Array.isArray(req.body.exclude) ? req.body.exclude : [];
 
-      log.debug('Getting contract for shard...');
       self._getContractForShard(contr, audit, bl, function(err, farmer, contr) {
         if (err) {
-          log.debug('Error getting contract for shard: %s', err);
-          return next(new errors.InternalError(err.message));
+          log.warn('Could not get contract for frame: %s and ' +
+                   'shard hash: %s, reason: %s', req.params.frame,
+                   req.body.hash, err.message);
+          return next(new errors.ServiceUnavailableError(err.message));
         }
-
-        log.debug('Successfully got contract for shard!');
 
         self.network.getConsignmentPointer(
           farmer,
@@ -209,10 +208,11 @@ FramesRouter.prototype.addShardToFrame = function(req, res, next) {
           audit,
           function(err, dcPointer) {
             if (err) {
-              return next(new errors.InternalError(err.message));
+              log.warn('Could not get consignment pointer for frame: %s, ' +
+                       'shard hash: %s, reason: %s', req.params.frame,
+                       req.body.hash, err.message);
+              return next(new errors.ServiceUnavailableError(err.message));
             }
-
-            log.debug('Got consign token, saving the frame and sending...');
 
             // We need to reload the frame to get the latest copy
             Frame.findOne({


### PR DESCRIPTION
Improves the ability to identify the source of timeout issues when trying to get storage offers in the Storj network, by making the logs searchable by frame and shard hash id, and logging specific details about the failure. This also changes the error type to ServiceUnavailable which is more fitting, and which can eventually be solved by having overflow farmers staged in the event that storage offers are not available.