### PR TITLE
Remove download count on storage item

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -995,7 +995,6 @@ BucketsRouter.prototype._getRetrievalToken = function(sPointer, opts, done) {
  * @param {BucketsRouter~_requestRetrievalPointerCallback}
  */
 BucketsRouter.prototype._requestRetrievalPointer = function(item, meta, done) {
-  const contracts = this.contracts;
   const network = this.network;
   const contract = item.getContract(meta.contact);
 

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1010,29 +1010,12 @@ BucketsRouter.prototype._requestRetrievalPointer = function(item, meta, done) {
       return done();
     }
 
-    if (!item.meta[meta.contact.nodeID]) {
-      item.addMetaData(meta.contact, { downloadCount: 0 });
-    }
+    meta.pointer = {
+      token: dcPointer.token,
+      farmer: meta.contact
+    };
 
-    if (!item.meta[meta.contact.nodeID].downloadCount) {
-      item.meta[meta.contact.nodeID].downloadCount = 0;
-    }
-
-    item.meta[meta.contact.nodeID].downloadCount++;
-
-    contracts.save(item, function(err) {
-      /* istanbul ignore if */
-      if (err) {
-        log.error('Failed to update download count: %s', err.message);
-      }
-
-      meta.pointer = {
-        token: dcPointer.token,
-        farmer: meta.contact
-      };
-
-      done(null, true);
-    });
+    done(null, true);
   });
 };
 /**

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -2600,9 +2600,6 @@ describe('BucketsRouter', function() {
         _save.restore();
         _contactFindOne.restore();
         _getRetrievalPointer.restore();
-        expect(
-          item.meta[storj.utils.rmd160('nodeid')].downloadCount
-        ).to.equal(1);
         expect(err).to.equal(null);
         expect(meta.pointer.token).to.equal('token');
         expect(meta.pointer.farmer.nodeID).to.equal(storj.utils.rmd160('nodeid'));


### PR DESCRIPTION
Storage events and exchange reports are used to track usage.

Fixes "Failed to update download count: No matching document found"

Also has the benefit that we don't need to wait to save before returning the token.