### PR TITLE
Be able to authenticate w/o token for getting file pointers

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1143,13 +1143,17 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
   const User = this.storage.models.User;
 
-  if (req.token && req.params.id !== req.token.bucket.toString()) {
-    return next(new errors.NotAuthorizedError());
+  const query = { _id: req.params.id };
+
+  if (req.user) {
+    query.user = req.user._id
+  } else {
+    if (req.params.id !== req.token.bucket.toString()) {
+      return next(new errors.NotAuthorizedError());
+    }
   }
 
-  Bucket.findOne({
-    _id: req.params.id
-  }, function(err, bucket) {
+  Bucket.findOne(query, function(err, bucket) {
     if (err) {
       return next(new errors.InternalError(err.message));
     }

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1146,7 +1146,7 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
   const query = { _id: req.params.id };
 
   if (req.user) {
-    query.user = req.user._id
+    query.user = req.user._id;
   } else {
     if (req.params.id !== req.token.bucket.toString()) {
       return next(new errors.NotAuthorizedError());

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ms = require('ms');
+const assert = require('assert');
 const async = require('async');
 const storj = require('storj-lib');
 const middleware = require('storj-service-middleware');
@@ -37,6 +38,23 @@ function BucketsRouter(options) {
 }
 
 inherits(BucketsRouter, Router);
+
+BucketsRouter.prototype._usetokenOrVerify = function(req, res, next) {
+  if (req.headers['x-token']) {
+    this._usetoken(req, res, next);
+  } else {
+    // NB: Authenticate middleware is array of rawbody and authenticate
+    assert(this._verify.length === 2);
+    const rawbody = this._verify[0];
+    const authenticate = this._verify[1];
+    rawbody(req, res, (err) => {
+      if (err) {
+        return next(err);
+      }
+      authenticate(req, res, next);
+    });
+  }
+};
 
 BucketsRouter.prototype._validate = function(req, res, next) {
   if (req.params.id && !utils.isValidObjectId(req.params.id)) {
@@ -1125,12 +1143,12 @@ BucketsRouter.prototype.getFile = function(req, res, next) {
   const BucketEntry = this.storage.models.BucketEntry;
   const User = this.storage.models.User;
 
-  if (req.params.id !== req.token.bucket.toString()) {
+  if (req.token && req.params.id !== req.token.bucket.toString()) {
     return next(new errors.NotAuthorizedError());
   }
 
   Bucket.findOne({
-    _id: req.token.bucket
+    _id: req.params.id
   }, function(err, bucket) {
     if (err) {
       return next(new errors.InternalError(err.message));
@@ -1404,7 +1422,7 @@ BucketsRouter.prototype._definitions = function() {
     ['POST', '/buckets/:id/tokens', this._limiter(defaults), this._validate, this._verify, this.createBucketToken],
     ['GET', '/buckets/:id/files', this._limiter(defaults), this._validate, this._verify, this.listFilesInBucket],
     ['GET', '/buckets/:id/file-ids/:name', this._limiter(defaults), this._validate, this._verify, this.getFileId],
-    ['GET', '/buckets/:id/files/:file', this._limiter(defaults), this._validate, this._usetoken, this.getFile],
+    ['GET', '/buckets/:id/files/:file', this._limiter(defaults), this._validate, this._usetokenOrVerify, this.getFile],
     ['DELETE', '/buckets/:id/files/:file', this._limiter(defaults), this._validate, this._verify, this.removeFile],
     ['GET', '/buckets/:id/files/:file/info', this._limiter(defaults), this._validate, this.getFileInfo],
     ['POST', '/buckets/:id/files', this._limiter(defaults), this._validate, this._verify, this.createEntryFromFrame],

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -3298,7 +3298,7 @@ describe('BucketsRouter', function() {
       bucketsRouter.getFile(request, response);
     });
 
-    it('should send retrieval pointers w/o token (using auth)', function(done) {
+    it('should send retrieval pointers w/o token (w/ user)', function(done) {
       var request = httpMocks.createRequest({
         method: 'GET',
         url: '/buckets/:bucket_id/files/:file_id',
@@ -3307,6 +3307,7 @@ describe('BucketsRouter', function() {
         },
         query: {}
       });
+      request.user = someUser;
       const testUser = new bucketsRouter.storage.models.User({
         _id: 'testuser@storj.io',
         hashpass: storj.utils.sha256('password')
@@ -3352,7 +3353,7 @@ describe('BucketsRouter', function() {
       ).callsArgWith(3, null, pointers);
       response.on('end', function() {
         expect(bucketsRouter.storage.models.Bucket.findOne.args[0][0])
-          .to.eql({ _id: 'bucketid' });
+          .to.eql({ _id: 'bucketid', user: 'gordon@storj.io' });
         expect(bucketsRouter._getPointersFromEntry.args[0][2])
           .to.equal(testUser);
         expect(JSON.stringify(response._getData())).to.equal(

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -44,6 +44,9 @@ describe('BucketsRouter', function() {
       };
       const res = {};
       router._usetokenOrVerify(req, res, (err) => {
+        if (err) {
+          return done(err);
+        }
         expect(router._verify[0].callCount).to.equal(1);
         expect(router._verify[0].args[0][0]).to.equal(req);
         expect(router._verify[0].args[0][1]).to.equal(res);
@@ -91,6 +94,9 @@ describe('BucketsRouter', function() {
       };
       const res = {};
       router._usetokenOrVerify(req, res, (err) => {
+        if (err) {
+          return done(err);
+        }
         expect(router._verify[0].callCount).to.equal(0);
         expect(router._verify[1].callCount).to.equal(0);
         expect(router._usetoken.callCount).to.equal(1);


### PR DESCRIPTION
This reduces number of requests for downloading files by more than 1/3, especially when requesting smaller portion of file pointers, instead of groups of six. This should help reduce the time needed to respond per request. Currently setting a client timeout of 20 seconds is too short for this request to reliably succeed. 60 seconds usually needed for group of 6 pointers.

Related: https://github.com/Storj/libstorj/issues/340