### PR TITLE
Don't use offline farmer as seed. Order by timeoutRate.

### DIFF
--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -103,7 +103,7 @@ Monitor.prototype._fetchSources = function(shard, callback) {
 
   this.storage.models.Contact
     .find({ _id: { $in: farmers }})
-    .sort({ lastSeen: -1 })
+    .sort({ timeoutRate: 1, lastSeen: -1 })
     .exec((err, results) => {
       if (err) {
         return callback(err);


### PR DESCRIPTION
Prevent a possible attack.

At he Moment the contact list is ordered by lastSeen. I could setup 30 farmer with wrong contact informations and nonstop pinging the bridge. My 30 farmer will fill the first page of the contact list. Other farmer are using the contact list as seed. They will not be able to connect to the storj network because not one of my 30 farmer is allive and can answer FIND_NODE requests.

This fix will order by timeoutRate first. My 30 fake farmer will be listed somewhere at the end.