### PR TITLE
Use shards collection for list mirrors

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -870,8 +870,8 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
         // will also not be populated, the farmer_id will be included
         // if there are additional details needed.
 
-        for (let nodeID in shard.contracts) {
-          let contract = shard.contracts[nodeID].contract;
+        for (let i = 0; i < shard.contracts.length; i++) {
+          let contract = shard.contracts[i].contract;
           established.push({
             shardHash: shard.hash,
             contract: {

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -851,9 +851,9 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
 
   function _getMirrorsFromHashes(hashes, callback) {
     async.map(hashes, function(hash, next) {
-      self.storage.models.Mirror.find({
-        shardHash: hash
-      }).populate('contact').exec((err, mirrors) => {
+      self.storage.models.Shard.findOne({
+        hash: hash
+      }).exec((err, shard) => {
         if (err) {
           return callback(err);
         }
@@ -861,9 +861,20 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
         let result = { established: [], available: [] };
         let { established, available } = result;
 
-        mirrors.forEach((mirror) => mirror.isEstablished ?
-          established.push(mirror.toObject()) :
-          available.push(mirror.toObject()));
+        // TODO check that shard is found and has contracts
+
+        // NOTE: Available is nolonger used here as available
+        // mirrors are stored in TTL collection.
+
+        for (var i = 0; i < shard.contracts.length; i++) {
+          let contract = shard.contracts.contract[i];
+          established.push({
+            shardHash: shard.hash,
+            contact: {}, // TODO
+            contract: contract, // TODO sanitize
+            isEstablished: true
+          })
+        }
 
         next(null, result);
       });

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -874,7 +874,6 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
           let contract = shard.contracts[nodeID].contract;
           established.push({
             shardHash: shard.hash,
-            contact: {},
             contract: {
               farmer_id: contract.farmer_id,
               data_size: contract.data_size,
@@ -882,7 +881,6 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
               store_end: contract.store_end,
               version: contract.version
             }
-            isEstablished: true
           })
         }
 

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -861,17 +861,27 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
         let result = { established: [], available: [] };
         let { established, available } = result;
 
-        // TODO check that shard is found and has contracts
+        if (!shard) {
+          next(null, result);
+        }
 
-        // NOTE: Available is nolonger used here as available
-        // mirrors are stored in TTL collection.
+        // NOTE: Available is no longer used here as available
+        // mirrors are stored in TTL collection. The contact field
+        // will also not be populated, the farmer_id will be included
+        // if there are additional details needed.
 
-        for (var i = 0; i < shard.contracts.length; i++) {
-          let contract = shard.contracts.contract[i];
+        for (let nodeID in shard.contracts) {
+          let contract = shard.contracts[nodeID].contract;
           established.push({
             shardHash: shard.hash,
-            contact: {}, // TODO
-            contract: contract, // TODO sanitize
+            contact: {},
+            contract: {
+              farmer_id: contract.farmer_id,
+              data_size: contract.data_size,
+              store_begin: contract.store_begin,
+              store_end: contract.store_end,
+              version: contract.version
+            }
             isEstablished: true
           })
         }

--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -855,14 +855,14 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
         hash: hash
       }).exec((err, shard) => {
         if (err) {
-          return callback(err);
+          return next(err);
         }
 
         let result = { established: [], available: [] };
-        let { established, available } = result;
+        let { established } = result;
 
         if (!shard) {
-          next(null, result);
+          return next(null, result);
         }
 
         // NOTE: Available is no longer used here as available
@@ -878,10 +878,9 @@ BucketsRouter.prototype.listMirrorsForFile = function(req, res, next) {
               farmer_id: contract.farmer_id,
               data_size: contract.data_size,
               store_begin: contract.store_begin,
-              store_end: contract.store_end,
-              version: contract.version
+              store_end: contract.store_end
             }
-          })
+          });
         }
 
         next(null, result);

--- a/test/server/routes/buckets.unit.js
+++ b/test/server/routes/buckets.unit.js
@@ -3370,6 +3370,8 @@ describe('BucketsRouter', function() {
   });
 
   describe('#listMirrorsForFile', function() {
+    const sandbox = sinon.sandbox.create();
+    afterEach(() => sandbox.restore());    
 
     it('should return the mirrors for the file', function(done) {
       var request = httpMocks.createRequest({
@@ -3385,38 +3387,38 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
-      var _getBucketById = sinon.stub(
+      var _getBucketById = sandbox.stub(
         bucketsRouter,
         '_getBucketById'
       ).callsArgWith(2, null, {
         id: 'bucketid'
       });
-      var _bucketEntryFindOne = sinon.stub(
+      var _bucketEntryFindOne = sandbox.stub(
         bucketsRouter.storage.models.BucketEntry,
         'findOne'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, {
+            exec: sandbox.stub().callsArgWith(0, null, {
               frame: { shards: [] }
             })
           };
         }
       });
-      var _pointerFind = sinon.stub(
+      var _pointerFind = sandbox.stub(
         bucketsRouter.storage.models.Pointer,
         'find'
       ).callsArgWith(1, null, [
         { hash: 'hash1' },
         { hash: 'hash2' }
       ]);
-      var _mirrorFind = sinon.stub(
+      var _mirrorFind = sandbox.stub(
         bucketsRouter.storage.models.Mirror,
         'find'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, [
+            exec: sandbox.stub().callsArgWith(0, null, [
               {
                 toObject: (() => 'MIRROR'),
                 isEstablished: true
@@ -3464,38 +3466,38 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
-      var _getBucketById = sinon.stub(
+      var _getBucketById = sandbox.stub(
         bucketsRouter,
         '_getBucketById'
       ).callsArgWith(2, null, {
         id: 'bucketid'
       });
-      var _bucketEntryFindOne = sinon.stub(
+      var _bucketEntryFindOne = sandbox.stub(
         bucketsRouter.storage.models.BucketEntry,
         'findOne'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, {
+            exec: sandbox.stub().callsArgWith(0, null, {
               frame: { shards: [] }
             })
           };
         }
       });
-      var _pointerFind = sinon.stub(
+      var _pointerFind = sandbox.stub(
         bucketsRouter.storage.models.Pointer,
         'find'
       ).callsArgWith(1, null, [
         { hash: 'hash1' },
         { hash: 'hash2' }
       ]);
-      var _mirrorFind = sinon.stub(
+      var _mirrorFind = sandbox.stub(
         bucketsRouter.storage.models.Mirror,
         'find'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(
+            exec: sandbox.stub().callsArgWith(
               0, new Error('Failed to find mirror')
             )
           };
@@ -3525,35 +3527,35 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
-      var _getBucketById = sinon.stub(
+      var _getBucketById = sandbox.stub(
         bucketsRouter,
         '_getBucketById'
       ).callsArgWith(2, null, {
         id: 'bucketid'
       });
-      var _bucketEntryFindOne = sinon.stub(
+      var _bucketEntryFindOne = sandbox.stub(
         bucketsRouter.storage.models.BucketEntry,
         'findOne'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, {
+            exec: sandbox.stub().callsArgWith(0, null, {
               frame: { shards: [] }
             })
           };
         }
       });
-      var _pointerFind = sinon.stub(
+      var _pointerFind = sandbox.stub(
         bucketsRouter.storage.models.Pointer,
         'find'
       ).callsArgWith(1, new Error('Failed to find pointers'));
-      var _mirrorFind = sinon.stub(
+      var _mirrorFind = sandbox.stub(
         bucketsRouter.storage.models.Mirror,
         'find'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, [
+            exec: sandbox.stub().callsArgWith(0, null, [
               {
                 toObject: (() => 'MIRROR'),
                 isEstablished: true
@@ -3595,36 +3597,36 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
-      var _getBucketById = sinon.stub(
+      var _getBucketById = sandbox.stub(
         bucketsRouter,
         '_getBucketById'
       ).callsArgWith(2, null, {
         id: 'bucketid'
       });
-      var _bucketEntryFindOne = sinon.stub(
+      var _bucketEntryFindOne = sandbox.stub(
         bucketsRouter.storage.models.BucketEntry,
         'findOne'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, new Error('Query failed'))
+            exec: sandbox.stub().callsArgWith(0, new Error('Query failed'))
           };
         }
       });
-      var _pointerFind = sinon.stub(
+      var _pointerFind = sandbox.stub(
         bucketsRouter.storage.models.Pointer,
         'find'
       ).callsArgWith(1, null, [
         { hash: 'hash1' },
         { hash: 'hash2' }
       ]);
-      var _mirrorFind = sinon.stub(
+      var _mirrorFind = sandbox.stub(
         bucketsRouter.storage.models.Mirror,
         'find'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, [
+            exec: sandbox.stub().callsArgWith(0, null, [
               {
                 toObject: (() => 'MIRROR'),
                 isEstablished: true
@@ -3666,36 +3668,36 @@ describe('BucketsRouter', function() {
         req: request,
         eventEmitter: EventEmitter
       });
-      var _getBucketById = sinon.stub(
+      var _getBucketById = sandbox.stub(
         bucketsRouter,
         '_getBucketById'
       ).callsArgWith(2, null, {
         id: 'bucketid'
       });
-      var _bucketEntryFindOne = sinon.stub(
+      var _bucketEntryFindOne = sandbox.stub(
         bucketsRouter.storage.models.BucketEntry,
         'findOne'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, null)
+            exec: sandbox.stub().callsArgWith(0, null, null)
           };
         }
       });
-      var _pointerFind = sinon.stub(
+      var _pointerFind = sandbox.stub(
         bucketsRouter.storage.models.Pointer,
         'find'
       ).callsArgWith(1, null, [
         { hash: 'hash1' },
         { hash: 'hash2' }
       ]);
-      var _mirrorFind = sinon.stub(
+      var _mirrorFind = sandbox.stub(
         bucketsRouter.storage.models.Mirror,
         'find'
       ).returns({
         populate: () => {
           return {
-            exec: sinon.stub().callsArgWith(0, null, [
+            exec: sandbox.stub().callsArgWith(0, null, [
               {
                 toObject: (() => 'MIRROR'),
                 isEstablished: true


### PR DESCRIPTION
This is necessary so that we can have the mirrors collection have a TTL as in https://github.com/Storj/service-storage-models/pull/118

**Note**: As contact details won't be included by default for this query, [tools](https://github.com/Storj/libstorj/blob/master/src/cli.c#L532) need to be updated to show the nodeID instead of IP address and port. That information can be retrieved if necessary from the nodeID. Additionally *available* mirrors won't be listed here.

Closes https://github.com/Storj/bridge/issues/427
Closes https://github.com/Storj/bridge/issues/470