### PR TITLE
Fixed type errors in the API specification

### DIFF
--- a/lib/apispec.json
+++ b/lib/apispec.json
@@ -110,7 +110,7 @@
                   },
                   "port": {
                     "description": "Port number the contact is listening on",
-                    "type": "number",
+                    "type": "integer",
                     "example": 8443
                   },
                   "nodeID": {
@@ -161,7 +161,7 @@
                 },
                 "port": {
                   "description": "Port number the contact is listening on",
-                  "type": "number",
+                  "type": "integer",
                   "example": 8443
                 },
                 "nodeID": {
@@ -735,12 +735,12 @@
                         "example": "fde400fe0b6a5488e10d7317274a096aaa57914d"
                       },
                       "size": {
-                        "type": "number",
+                        "type": "integer",
                         "description": "The number of bytes in the shard",
                         "example": 4096
                       },
                       "index": {
-                        "type": "number",
+                        "type": "integer",
                         "description": "The order index of the shard in the file",
                         "example": 0
                       }
@@ -780,12 +780,12 @@
                   "example": "fde400fe0b6a5488e10d7317274a096aaa57914d"
                 },
                 "size": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "The number of bytes in the shard",
                   "example": 4096
                 },
                 "index": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "The order index of the shard in the file",
                   "example": 0
                 },
@@ -867,8 +867,8 @@
                       "description": "Storj user agent string for farming client"
                     },
                     "port": {
-                      "type": "number",
-                      "example": "8448",
+                      "type": "integer",
+                      "example": 8448,
                       "description": "Port number the farmer is listening on"
                     }
                   }
@@ -929,12 +929,12 @@
                 "type": "object",
                 "properties": {
                   "storage": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Amount of storage space in GB",
                     "example": 10
                   },
                   "transfer": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Amount of transfer in GB",
                     "example": 30
                   },
@@ -1017,12 +1017,12 @@
               "type": "object",
               "properties": {
                 "storage": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "Amount of storage space in GB",
                   "example": 10
                 },
                 "transfer": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "Amount of transfer in GB",
                   "example": 30
                 },
@@ -1090,12 +1090,12 @@
               "type": "object",
               "properties": {
                 "storage": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "Amount of storage space in GB",
                   "example": 30
                 },
                 "transfer": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "Amount of transfer in GB",
                   "example": 50
                 },
@@ -1183,12 +1183,12 @@
               "type": "object",
               "properties": {
                 "storage": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "Amount of storage space in GB",
                   "example": 30
                 },
                 "transfer": {
-                  "type": "number",
+                  "type": "integer",
                   "description": "Amount of transfer in GB",
                   "example": 50
                 },
@@ -1410,7 +1410,7 @@
                   "example": "big_buck_bunny.mp4"
                 },
                 "size": {
-                  "type": "number",
+                  "type": "integer",
                   "example": 5071076
                 },
                 "created": {
@@ -1485,7 +1485,7 @@
                     "example": "big_buck_bunny.mp4"
                   },
                   "size": {
-                    "type": "number",
+                    "type": "integer",
                     "example": 5071076
                   },
                   "frame": {
@@ -1617,8 +1617,8 @@
                         "description": "Storj user agent string for farming client"
                       },
                       "port": {
-                        "type": "number",
-                        "example": "8448",
+                        "type": "integer",
+                        "example": 8448,
                         "description": "Port number the farmer is listening on"
                       }
                     }
@@ -1712,7 +1712,7 @@
                   "example": "507f1f77bcf86cd799430909"
                 },
                 "size": {
-                  "type": "number",
+                  "type": "integer",
                   "example": 5071076
                 },
                 "created": {

--- a/lib/apispec.json
+++ b/lib/apispec.json
@@ -1316,7 +1316,7 @@
                   "description": "Bucket encryption key if the bucket is public"
                 },
                 "size": {
-                  "type": "string",
+                  "type": "integer",
                   "description": "Size of file if file ID is sent as argument"
                 },
                 "mimetype": {

--- a/lib/apispec.json
+++ b/lib/apispec.json
@@ -852,8 +852,8 @@
                       "description": "ECDSA pubkeyhash identifier"
                     },
                     "lastSeen": {
-                      "type": "number",
-                      "example": "1487712850023",
+                      "type": "string",
+                      "example": "2016-05-24T15:16:01.139Z",
                       "description": "Timestamp when we last encountered this peer"
                     },
                     "address": {
@@ -1602,8 +1602,8 @@
                         "description": "ECDSA pubkeyhash identifier"
                       },
                       "lastSeen": {
-                        "type": "number",
-                        "example": "1487712850023",
+                        "type": "string",
+                        "example": "2016-05-24T15:16:01.139Z",
                         "description": "Timestamp when we last encountered this peer"
                       },
                       "address": {


### PR DESCRIPTION
When I accessed api.storj.io by a Swagger client, I got the following type errors:

- lastSeen of farmer is defined as an integer but a RFC3339 formatted string is returned,
- size is defined as a string but an integer is returned.

This PR fixed these errors. 

Additionally, I modify types of some variables from number to integer since variables defined as number type are treated as float values in some clients. It doesn't cause errors but, for example, port numbers in float type seem a little strange.