### PR TITLE
trigger new mirror on MIRROR_FAILED

### DIFF
--- a/lib/server/routes/reports.js
+++ b/lib/server/routes/reports.js
@@ -80,6 +80,7 @@ ReportsRouter.prototype._handleExchangeReport = function(report, callback) {
 
   switch (exchangeResultMessage) {
     case 'MIRROR_SUCCESS':
+    case 'MIRROR_FAILED':
     case 'SHARD_UPLOADED':
     case 'DOWNLOAD_ERROR':
       this._triggerMirrorEstablish(constants.M_REPLICATE, dataHash, callback);

--- a/test/server/routes/reports.unit.js
+++ b/test/server/routes/reports.unit.js
@@ -235,6 +235,13 @@ describe('ReportsRouter', function() {
       }, done);
     });
 
+    it('should trigger a mirror on MIRROR_FAILED', function(done) {
+      reportsRouter._handleExchangeReport({
+        shardHash: 'hash',
+        exchangeResultMessage: 'MIRROR_FAILED'
+      }, done);
+    });
+
     it('should trigger a mirror on DOWNLOAD_ERROR', function(done) {
       reportsRouter._handleExchangeReport({
         shardHash: 'hash',


### PR DESCRIPTION
This should improve the mirror situation. If the farmer was not able to create a mirror we will create another mirror.

One last case is not handled. The farmer can send an `FAILED_INTEGRITY` but the problem is that this report is used twice. Shard upload can fail with the same report. In that case we don't want to create any mirrors.

A possible solution would be using `MIRROR_FAILED` instead of `FAILED_INTEGRITY` for mirror creation and keep `FAILED_INTEGRITY` for shard upload. If you like I can submit a core pull request.