### PR TITLE
Switch to select by reputation

### DIFF
--- a/lib/server/routes/frames.js
+++ b/lib/server/routes/frames.js
@@ -13,6 +13,7 @@ const log = require('../../logger');
 const constants = require('../../constants');
 const analytics = require('storj-analytics');
 const limiter = require('../limiter').DEFAULTS;
+const utils = require('../../utils');
 
 /**
  * Handles endpoints for all frame/file staging related operations
@@ -322,7 +323,7 @@ FramesRouter.prototype.addShardToFrame = function(req, res, next) {
             return false;
           });
 
-          filtered.sort(FramesRouter._sortByResponseTime);
+          filtered.sort(utils.sortByReputation);
 
           mirror = filtered[0];
         }

--- a/lib/server/routes/reports.js
+++ b/lib/server/routes/reports.js
@@ -10,6 +10,7 @@ const constants = require('../../constants');
 const async = require('async');
 const storj = require('storj-lib');
 const limiter = require('../limiter').DEFAULTS;
+const utils = require('../../utils');
 
 /**
  * Handles endpoints for reporting
@@ -150,7 +151,7 @@ ReportsRouter.prototype._triggerMirrorEstablish = function(n, hash, done) {
       return callback(new Error('Auto mirroring limit is reached'));
     }
 
-    available.sort(ReportsRouter._sortByTimeoutRate);
+    available.sort(utils.sortByReputation);
 
     callback(null, available.shift());
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,17 @@ module.exports.createArrayFormatter = function(transformer) {
 };
 
 /**
+ * Sort by reputation, to be used with Array.prototype.sort
+ * @param {Object} - a
+ * @param {Object} - b
+ */
+module.exports.sortByReputation = function(a, b) {
+  const a1 = a.contact.reputation >= 0 ? a.contact.reputation : 0;
+  const b1 = b.contact.reputation >= 0 ? b.contact.reputation : 0;
+  return (a1 === b1) ? 0 : (a1 > b1) ? -1 : 1;
+};
+
+/**
  * Will get a timestamp integer from a string or number
  * argument, including ISO formatted strings.
  * @param {*} - The variable to parse

--- a/test/server/routes/frames.unit.js
+++ b/test/server/routes/frames.unit.js
@@ -1262,7 +1262,7 @@ describe('FramesRouter', function() {
       ).callsArgWith(1, null, frame0);
 
       const farmer = {
-        responseTime: 100,
+        reputation: 5000,
         nodeID: storj.utils.rmd160('farmer'),
         address: '127.0.0.1',
         port: 8080
@@ -1274,7 +1274,7 @@ describe('FramesRouter', function() {
 
       const mirrors = [
         {
-          contact: { responseTime: 10100 },
+          contact: { reputation: 1000  },
           isEstablished: false
         },
         {
@@ -1289,15 +1289,15 @@ describe('FramesRouter', function() {
         },
         { },
         {
-          contact: { responseTime: 200 },
+          contact: { reputation: 4000 },
           isEstablished: true
         },
         {
-          contact: { responseTime: 4100 },
+          contact: { responseTime: 2000 },
           isEstablished: true
         },
         {
-          contact: { responseTime: 2100 },
+          contact: { reputation: 3000 },
           isEstablished: false
         }
       ];

--- a/test/server/routes/reports.unit.js
+++ b/test/server/routes/reports.unit.js
@@ -8,6 +8,7 @@ const expect = require('chai').expect;
 const errors = require('storj-service-error-types');
 const EventEmitter = require('events').EventEmitter;
 const ReportsRouter = require('../../../lib/server/routes/reports');
+const utils = require('../../../lib/utils');
 
 describe('ReportsRouter', function() {
 
@@ -420,7 +421,7 @@ describe('ReportsRouter', function() {
         expect(err).to.equal(null);
         expect(Array.prototype.sort.callCount).to.equal(1);
         expect(Array.prototype.sort.args[0][0])
-          .to.equal(ReportsRouter._sortByTimeoutRate);
+          .to.equal(utils.sortByReputation);
         done();
       });
     });

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -92,4 +92,38 @@ describe('module:utils', function() {
     });
   });
 
+  describe('@sortByReputation', function() {
+    it('will sort with best reputation at the top', function() {
+      const mirrors = [{
+        contact: { reputation: 100 },
+      }, {
+        contact: { reputation: 1287 },
+      }, {
+        contact: { reputation: 5000 },
+      }, {
+        contact: { reputation: 4500 },
+      }, {
+        contact: { },
+      }, {
+        contact: { reputation: 300 },
+      }];
+
+      mirrors.sort(utils.sortByReputation);
+
+      expect(mirrors).to.eql([{
+        contact: { reputation: 5000 },
+      }, {
+        contact: { reputation: 4500 },
+      }, {
+        contact: { reputation: 1287 },
+      }, {
+        contact: { reputation: 300 },
+      }, {
+        contact: { reputation: 100 },
+      }, {
+        contact: { },
+      }]);
+    });
+  });
+
 });


### PR DESCRIPTION
For clarity, this only changes privatization for mirror selection to be based on reputation, which is currently using timeoutRate that has a reset bug.

Closes https://github.com/Storj/bridge/issues/536
Closes https://github.com/Storj/bridge/issues/526
Closes https://github.com/Storj/complex/issues/81 (no longer necessary)