### PR TITLE
addresses issue 510, changes a method to return last farmer not first

### DIFF
--- a/lib/server/routes/reports.js
+++ b/lib/server/routes/reports.js
@@ -162,7 +162,7 @@ ReportsRouter.prototype._triggerMirrorEstablish = function(n, hash, done) {
     let contact = storj.Contact(mirror.contact.toObject());
 
     async.until(test, (done) => {
-      self.getContactById(farmers.shift(), (err, result) => {
+      self.getContactById(farmers.pop(), (err, result) => {
         if (err) {
           return done();
         }

--- a/test/monitor/config.unit.js
+++ b/test/monitor/config.unit.js
@@ -103,7 +103,7 @@ describe('Monitor Config', function() {
     it('will throw if not an absolute config path', function() {
       expect(function() {
         MonitorConfig.getPaths('tmp/storj-monitor-test.json');
-      }).to.throw('Assertion');
+      }).to.throw('confpath is expected to be absolute');
     });
 
     it('will get the directory name from path', function() {

--- a/test/monitor/index.unit.js
+++ b/test/monitor/index.unit.js
@@ -910,7 +910,7 @@ describe('Monitor', function() {
       const monitor = new Monitor(config);
       expect(function() {
         monitor._randomTime(300000, 600000);
-      }).to.throw('Assertion');
+      }).to.throw('maxInterval is expected to be greater than minInterval');
     });
 
   });


### PR DESCRIPTION
The changes to tests are to fix errors occurring when running tests with Node v8-- unrelated to the `.shift()` to `.pop()` change in returning farmers.