### PR TITLE
Give default values for responseTime and reputation if not already set

### DIFF
--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -90,7 +90,7 @@ ContactsRouter.prototype.setDefaultResponseTime = function(nodeID) {
     responseTime: 10000
   }, {
     upsert: false
-  }, (err, contact) => {
+  }, (err) => {
     if (err) {
       log.error('Error setting default responseTime for %s, reason: %s',
                 nodeID, err.message);
@@ -106,7 +106,7 @@ ContactsRouter.prototype.setDefaultReputation = function(nodeID) {
     reputation: 0
   }, {
     upsert: false
-  }, (err, contact) => {
+  }, (err) => {
     if (err) {
       log.error('Error setting default reputation for %s, reason: %s',
                 nodeID, err.message);

--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -160,7 +160,8 @@ ContactsRouter.prototype.patchContactByNodeID = function(req, res, next) {
     res.status(201).send({
       nodeID: contact.nodeID,
       address: contact.address,
-      port: contact.port
+      port: contact.port,
+      spaceAvailable: contact.spaceAvailable
     });
   });
 };

--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -81,6 +81,14 @@ ContactsRouter.prototype.createContact = function(req, res, next) {
   });
 };
 
+ContactsRouter.prototype.setDefaultResponseTime = function(nodeID) {
+
+};
+
+ContactsRouter.prototype.setDefaultReputation = function(nodeID) {
+
+};
+
 ContactsRouter.prototype.patchContactByNodeID = function(req, res, next) {
   const Contact = this.storage.models.Contact;
   const nodeID = req.headers['x-node-id'];
@@ -105,13 +113,19 @@ ContactsRouter.prototype.patchContactByNodeID = function(req, res, next) {
 
   Contact.findOneAndUpdate({ _id: nodeID }, data, {
     upsert: false,
-    new: false
-  }, function(err, contact) {
+    returnNewDocument: true
+  }, (err, contact) => {
     if (err) {
       return next(new errors.InternalError(err.message));
     }
     if (!contact) {
       return next(new errors.NotFoundError('Contact not found'));
+    }
+    if (!contact.responseTime) {
+      this.setDefaultResponseTime(nodeID);
+    }
+    if (!contact.reputation) {
+      this.setDefaultReputation(nodeID);
     }
 
     res.status(201).send({

--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -4,6 +4,7 @@ const Router = require('./index');
 const errors = require('storj-service-error-types');
 const inherits = require('util').inherits;
 const middleware = require('storj-service-middleware');
+const log = require('../../logger');
 const limiter = require('../limiter').DEFAULTS;
 const rawBody = require('../middleware/raw-body');
 const {getPOWMiddleware, getChallenge} = require('../middleware/pow');
@@ -82,11 +83,35 @@ ContactsRouter.prototype.createContact = function(req, res, next) {
 };
 
 ContactsRouter.prototype.setDefaultResponseTime = function(nodeID) {
-
+  this.storage.models.Contact.findOneAndUpdate({
+    _id: nodeID,
+    responseTime: { $exists: false }
+  }, {
+    responseTime: 10000
+  }, {
+    upsert: false
+  }, (err, contact) => {
+    if (err) {
+      log.error('Error setting default responseTime for %s, reason: %s',
+                nodeID, err.message);
+    }
+  });
 };
 
 ContactsRouter.prototype.setDefaultReputation = function(nodeID) {
-
+  this.storage.models.Contact.findOneAndUpdate({
+    _id: nodeID,
+    reputation: { $exists: false }
+  }, {
+    reputation: 0
+  }, {
+    upsert: false
+  }, (err, contact) => {
+    if (err) {
+      log.error('Error setting default reputation for %s, reason: %s',
+                nodeID, err.message);
+    }
+  });
 };
 
 ContactsRouter.prototype.patchContactByNodeID = function(req, res, next) {

--- a/lib/server/routes/contacts.js
+++ b/lib/server/routes/contacts.js
@@ -87,7 +87,9 @@ ContactsRouter.prototype.setDefaultResponseTime = function(nodeID) {
     _id: nodeID,
     responseTime: { $exists: false }
   }, {
-    responseTime: 10000
+    $set: {
+      responseTime: 10000
+    }
   }, {
     upsert: false
   }, (err) => {
@@ -103,7 +105,9 @@ ContactsRouter.prototype.setDefaultReputation = function(nodeID) {
     _id: nodeID,
     reputation: { $exists: false }
   }, {
-    reputation: 0
+    $set: {
+      reputation: 0
+    }
   }, {
     upsert: false
   }, (err) => {
@@ -136,7 +140,7 @@ ContactsRouter.prototype.patchContactByNodeID = function(req, res, next) {
     data.spaceAvailable = req.body.spaceAvailable;
   }
 
-  Contact.findOneAndUpdate({ _id: nodeID }, data, {
+  Contact.findOneAndUpdate({ _id: nodeID }, { $set: data }, {
     upsert: false,
     returnNewDocument: true
   }, (err, contact) => {

--- a/test/server/routes/contacts.unit.js
+++ b/test/server/routes/contacts.unit.js
@@ -92,6 +92,57 @@ describe('ContactsRouter', function() {
 
   });
 
+  describe('#patchContactByNodeID', function() {
+    const sandbox = sinon.sandbox.create();
+    afterEach(() => sandbox.restore());
+
+    it('will send back a response on success', function(done) {
+      var request = httpMocks.createRequest({
+        method: 'PATCH',
+        url: '/contacts/somenodeid',
+        body: {
+          address: '127.0.0.1',
+          port: 9000,
+          spaceAvailable: false
+        }
+      });
+      var response = httpMocks.createResponse({
+        req: request,
+        eventEmitter: EventEmitter
+      });
+      const contact = {
+        address: '127.0.0.1',
+        port: 9000,
+        spaceAvailable: false
+      };
+
+      const findOneAndUpdate = sandbox.stub(
+        contactsRouter.storage.models.Contact,
+        'findOneAndUpdate'
+      ).callsArgWith(3, null, contact);
+
+      sandbox.stub(contactsRouter, 'setDefaultResponseTime');
+      sandbox.stub(contactsRouter, 'setDefaultReputation');
+
+      response.on('end', function() {
+        var result = response._getData();
+        expect(findOneAndUpdate.callCount).to.equal(1);
+        expect(findOneAndUpdate.args[0][1]).to.eql({
+          $set: {
+            address: '127.0.0.1',
+            port: 9000,
+            spaceAvailable: false
+          }
+        });
+        expect(contactsRouter.setDefaultResponseTime.callCount).to.equal(1);
+        expect(contactsRouter.setDefaultReputation.callCount).to.equal(1);
+        done();
+      });
+
+      contactsRouter.patchContactByNodeID(request, response, function() {});
+    });
+  });
+
   describe('#getContactByNodeID', function() {
 
     it('should return internal error if query fails', function(done) {

--- a/test/server/routes/contacts.unit.js
+++ b/test/server/routes/contacts.unit.js
@@ -111,6 +111,7 @@ describe('ContactsRouter', function() {
         eventEmitter: EventEmitter
       });
       const contact = {
+        nodeID: '13a01f6d2cda65982e452c841690ee32e6f88fb6',
         address: '127.0.0.1',
         port: 9000,
         spaceAvailable: false
@@ -126,6 +127,12 @@ describe('ContactsRouter', function() {
 
       response.on('end', function() {
         var result = response._getData();
+        expect(result).to.eql({
+          nodeID: '13a01f6d2cda65982e452c841690ee32e6f88fb6',
+          address: '127.0.0.1',
+          port: 9000,
+          spaceAvailable: false
+        });
         expect(findOneAndUpdate.callCount).to.equal(1);
         expect(findOneAndUpdate.args[0][1]).to.eql({
           $set: {


### PR DESCRIPTION
This covers the case that a contact is added via Kad which does not have these default values set. Because the contact will need to be updated with `spaceAvailable:true` to start receiving data, we can also verify that responseTime and reputation have default values so that the farmer will be selected to store data.
 
cc: @tempestb @littleskunk