### PR TITLE
add `GET /resets/:token` route back

### DIFF
--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const url = require('url');
 const assert = require('assert');
 const Router = require('./index');
 const middleware = require('storj-service-middleware');
@@ -469,6 +470,17 @@ UsersRouter.prototype.confirmPasswordReset = function(req, res, next) {
   });
 };
 
+UsersRouter.prototype.redirectToPasswordReset = function(req, res, next) {
+  const {host: hostname, port} = self.config.server.public || self.config.server;
+  const {ssl} = self.config.server;
+  const protocol = ssl && ssl.cert && ssl.key ?
+                'https' : 'http';
+  const backendUrl  = url.format({protocol, hostname, port));
+  const frontendUrl = backendUrl.replace(/^(https?)api/, '$1app');
+  //NB: type coercion is intentional
+  res.redirect(frontendurl);
+};
+
 /**
  * Export definitions
  * @private
@@ -481,6 +493,7 @@ UsersRouter.prototype._definitions = function() {
     ['DELETE', '/users/:id', this.getLimiter(limiter(5)), this._verify, this.destroyUser],
     ['GET', '/deactivations/:token', this.getLimiter(limiter(5)), this.confirmDestroyUser],
     ['PATCH', '/users/:id', this.getLimiter(limiter(5)), rawbody, this.createPasswordResetToken],
+    ['GET', '/resets/:token', this.getLimiter(limiter(5)), this.redirectToPasswordReset],
     ['POST', '/resets/:token', rawbody, this.getLimiter(limiter(5)), this.confirmPasswordReset]
   ];
 };

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -470,15 +470,15 @@ UsersRouter.prototype.confirmPasswordReset = function(req, res, next) {
   });
 };
 
-UsersRouter.prototype.redirectToPasswordReset = function(req, res, next) {
-  const {host: hostname, port} = self.config.server.public || self.config.server;
-  const {ssl} = self.config.server;
+UsersRouter.prototype.redirectToPasswordReset = function(req, res) {
+  const {host: hostname, port} = this.config.server.public || this.config.server;
+  const {ssl} = this.config.server;
   const protocol = ssl && ssl.cert && ssl.key ?
                 'https' : 'http';
   const backendUrl  = url.format({protocol, hostname, port});
   const frontendUrl = backendUrl.replace(/^(https?)api/, '$1app');
   //NB: type coercion is intentional
-  res.redirect(frontendurl);
+  res.redirect(frontendUrl);
 };
 
 /**

--- a/lib/server/routes/users.js
+++ b/lib/server/routes/users.js
@@ -475,7 +475,7 @@ UsersRouter.prototype.redirectToPasswordReset = function(req, res, next) {
   const {ssl} = self.config.server;
   const protocol = ssl && ssl.cert && ssl.key ?
                 'https' : 'http';
-  const backendUrl  = url.format({protocol, hostname, port));
+  const backendUrl  = url.format({protocol, hostname, port});
   const frontendUrl = backendUrl.replace(/^(https?)api/, '$1app');
   //NB: type coercion is intentional
   res.redirect(frontendurl);


### PR DESCRIPTION
Add `GET /resets/:token` to avoid changing [service-mailer templates](https://github.com/Storj/service-mailer/blob/master/templates/reset.html) and allow bridge to redirect to the new, correct frontend (i.e. bridge-gui-vue) url.